### PR TITLE
QOL improvements: Navigation back stacks and prompt generation errors

### DIFF
--- a/app/src/main/java/com/android/developers/androidify/navigation/MainNavigation.kt
+++ b/app/src/main/java/com/android/developers/androidify/navigation/MainNavigation.kt
@@ -89,7 +89,6 @@ fun MainNavigation() {
                 fadeIn(motionScheme.defaultEffectsSpec()),
                 scaleOut(
                     targetScale = 0.7f,
-                    transformOrigin = TransformOrigin(pivotFractionX = 0.5f, pivotFractionY = 0.5f),
                 ),
             )
         },
@@ -108,7 +107,9 @@ fun MainNavigation() {
             entry<Camera> {
                 CameraPreviewScreen(
                     onImageCaptured = { uri ->
+                        backStack.removeAll { it is Create }
                         backStack.add(Create(uri.toString()))
+                        backStack.removeAll { it is Camera }
                     },
                 )
             }
@@ -116,6 +117,7 @@ fun MainNavigation() {
                 CreationScreen(
                     createKey.fileName,
                     onCameraPressed = {
+                        backStack.removeAll { it is Camera }
                         backStack.add(Camera)
                     },
                     onBackPressed = {
@@ -142,7 +144,7 @@ fun MainNavigation() {
                 showSplash = false
             },
             onTransitionMidpoint = {
-                backStack.add(Create())
+                backStack.add(Create(fileName = null))
             },
         )
     }

--- a/feature/camera/src/main/java/com/android/developers/androidify/camera/CameraScreen.kt
+++ b/feature/camera/src/main/java/com/android/developers/androidify/camera/CameraScreen.kt
@@ -137,6 +137,7 @@ fun CameraPreviewScreen(
                     // so CameraX can retrieve the new Surface.
                     LaunchedEffect(surface) {
                         val oldIsTableTop = isTableTopPosture(foldingFeature)
+
                         snapshotFlow { foldingFeature }
                             .takeWhile {
                                 val newIsTableTop = isTableTopPosture(it)

--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationScreen.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationScreen.kt
@@ -169,6 +169,7 @@ fun CreationScreen(
     }
     LaunchedEffect(Unit) {
         if (fileName != null) creationViewModel.onImageSelected(fileName.toUri())
+        else creationViewModel.onImageSelected(null)
     }
     val pickMedia = rememberLauncherForActivityResult(PickVisualMedia()) { uri ->
         if (uri != null) {

--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationViewModel.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationViewModel.kt
@@ -89,7 +89,7 @@ class CreationViewModel @Inject constructor(
     val snackbarHostState: StateFlow<SnackbarHostState>
         get() = _snackbarHostState
 
-    fun onImageSelected(uri: Uri) {
+    fun onImageSelected(uri: Uri?) {
         _uiState.update {
             it.copy(
                 imageUri = uri,
@@ -116,14 +116,21 @@ class CreationViewModel @Inject constructor(
             _uiState.update {
                 it.copy(promptGenerationInProgress = true)
             }
-            val prompt = textGenerationRepository.getNextGeneratedBotPrompt()
-            Log.d("CreationViewModel", "Prompt: $prompt")
-            if (prompt != null) {
+            try {
+                val prompt = textGenerationRepository.getNextGeneratedBotPrompt()
+                Log.d("CreationViewModel", "Prompt: $prompt")
+                if (prompt != null) {
+                    _uiState.update {
+                        it.copy(
+                            generatedPrompt = prompt,
+                            promptGenerationInProgress = false,
+                        )
+                    }
+                }
+            } catch (exception: Exception) {
+                Log.e("CreationViewModel", "Error generating prompt", exception)
                 _uiState.update {
-                    it.copy(
-                        generatedPrompt = prompt,
-                        promptGenerationInProgress = false,
-                    )
+                    it.copy(promptGenerationInProgress = false)
                 }
             }
         }


### PR DESCRIPTION
When DNS servers are failing, the prompt generation of "Help me write" doesn't work properly - it can crash, even though we check for if internet is available, we need to also check for exceptions here.

The backstack when using a Camera was also adding a few too many Camera items to the backstack, this ensures there is only one when its shown - and not added to the backstack when navigating away from the screen. 