### PR TITLE
Replace CameraScreen workaround with proper fix

### DIFF
--- a/feature/camera/src/main/java/com/android/developers/androidify/camera/CameraScreen.kt
+++ b/feature/camera/src/main/java/com/android/developers/androidify/camera/CameraScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -71,7 +70,6 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.google.accompanist.permissions.shouldShowRationale
-import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
 
 @OptIn(
@@ -131,22 +129,6 @@ fun CameraPreviewScreen(
                 }
 
                 uiState.surfaceRequest?.let { surface ->
-                    // Workaround for https://issuetracker.google.com/275157240
-                    // When switching to/from tabletop posture, the underlying SurfaceView
-                    // destroys its Surface. Invalidate the SurfaceRequest when this happens
-                    // so CameraX can retrieve the new Surface.
-                    LaunchedEffect(surface) {
-                        val oldIsTableTop = isTableTopPosture(foldingFeature)
-
-                        snapshotFlow { foldingFeature }
-                            .takeWhile {
-                                val newIsTableTop = isTableTopPosture(it)
-                                val shouldInvalidate = oldIsTableTop != newIsTableTop
-                                if (shouldInvalidate) surface.invalidate()
-                                !shouldInvalidate
-                            }.collect {}
-                    }
-
                     CameraPreviewContent(
                         surfaceRequest = surface,
                         autofocusUiState = uiState.autofocusUiState,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ pluginManagement {
         maven {
             // You can find the maven URL for other artifacts (e.g. KMP, METALAVA) on their
             // build pages.
-            url = uri("https://androidx.dev/snapshots/builds/13496591/artifacts/repository")
+            url = uri("https://androidx.dev/snapshots/builds/13511472/artifacts/repository")
         }
 
     }
@@ -23,7 +23,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven {
-            url = uri("https://androidx.dev/snapshots/builds/13496591/artifacts/repository")
+            url = uri("https://androidx.dev/snapshots/builds/13511472/artifacts/repository")
         }
     }
 }


### PR DESCRIPTION
 The issue being worked around with PR#4 was fixed in CameraX in
 https://android-review.googlesource.com/c/platform/frameworks/support/+/3630671
 This fixes some of the instability with rotation, as well as with tabletop
 mode, allowing us to remove the workaround.
