### PR TITLE
Docs: Update README with fontName property location

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The app combines a variety of different Google technologies, such as:
 [`remote_config_defaults.xml`](core/network/src/main/res/xml/remote_config_defaults.xml)
 
 4. If you'd like to change the font that the app renders with, an optional spec can be placed in
-   `~/gradlew/gradle.properties` file:
+   the project's `gradle.properties` file:
 
 ```
 fontName="Roboto Flex"


### PR DESCRIPTION
This pull request includes a small update to the project's documentation in `README.md`. The change clarifies the file location for customizing the app's font by specifying it as the project's `gradle.properties` file instead of `~/gradlew/gradle.properties`.