### PR TITLE
Fix crash on rapid back press by checking back stack state before removal

### DIFF
--- a/app/src/main/java/com/android/developers/androidify/navigation/MainNavigation.kt
+++ b/app/src/main/java/com/android/developers/androidify/navigation/MainNavigation.kt
@@ -121,7 +121,9 @@ fun MainNavigation() {
                         backStack.add(Camera)
                     },
                     onBackPressed = {
-                        backStack.removeLastOrNull()
+                        if (backStack.isNotEmpty() && backStack.last() is Create) {
+                            backStack.removeLastOrNull()
+                        }
                     },
                     onAboutPressed = {
                         backStack.add(About)
@@ -131,7 +133,9 @@ fun MainNavigation() {
             entry<About> {
                 AboutScreen(
                     onBackPressed = {
-                        backStack.removeLastOrNull()
+                        if (backStack.isNotEmpty() && backStack.last() is About) {
+                            backStack.removeLastOrNull()
+                        }
                     },
                 )
             }


### PR DESCRIPTION
## Summary
This PR fixes a crash that occurs when the back button is pressed rapidly while on certain screens (e.g. `Create`, `About`). 

The issue was caused by `backStack.removeLastOrNull()` being called without validating the current top of the back stack, leading to `IllegalArgumentException: NavDisplay backstack cannot be empty`.

## Changes
- Added type-checks before removing the top of the back stack to ensure the app is in a valid navigation state.
- Specifically checks if `backStack.last()` is of type `Create` or `About` before removing it.


