### PR TITLE
Fix: Synchronize Toolbar with page state only after HorizontalPager animation completes

### DIFF
--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationScreen.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationScreen.kt
@@ -151,7 +151,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import com.android.developers.androidify.creation.R as CreationR
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun CreationScreen(
     fileName: String? = null,

--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationScreen.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationScreen.kt
@@ -363,7 +363,9 @@ fun EditScreen(
                     }
                 } else {
                     BottomButtons(
-                        onButtonColorClicked = { showColorPickerBottomSheet = !showColorPickerBottomSheet },
+                        onButtonColorClicked = {
+                            showColorPickerBottomSheet = !showColorPickerBottomSheet
+                        },
                         uiState = uiState,
                         onStartClicked = onStartClicked,
                         modifier = Modifier
@@ -403,10 +405,16 @@ private fun MainCreationPane(
         val pagerState = rememberPagerState(0) { PromptType.entries.size }
         val focusManager = LocalFocusManager.current
         LaunchedEffect(uiState.selectedPromptOption) {
-            pagerState.animateScrollToPage(
-                uiState.selectedPromptOption.ordinal,
-                animationSpec = spatialSpec,
-            )
+            launch {
+                pagerState.animateScrollToPage(
+                    uiState.selectedPromptOption.ordinal,
+                    animationSpec = spatialSpec,
+                )
+            }.invokeOnCompletion {
+                if (uiState.selectedPromptOption != PromptType.entries[pagerState.currentPage]) {
+                    onSelectedPromptOptionChanged(PromptType.entries[pagerState.currentPage])
+                }
+            }
         }
         LaunchedEffect(pagerState) {
             snapshotFlow { pagerState.currentPage }.collect { page ->


### PR DESCRIPTION
## Summary of changes
- Modified the logic so that the ViewModel state and the actual pager's current page are synchronized **only after** the HorizontalPager's page transition animation completes.
- This change prevents the Toolbar (page title) and the visible page from becoming out of sync during page transitions.

## Related Issue
- Closes #15

## Detailed changes
- Added synchronization of the ViewModel state with the current pager page in the `invokeOnCompletion` block after `animateScrollToPage` inside `LaunchedEffect(uiState.selectedPromptOption)`.

## Code example
```kotlin
LaunchedEffect(uiState.selectedPromptOption) {
    launch {
        pagerState.animateScrollToPage(
            uiState.selectedPromptOption.ordinal,
            animationSpec = spatialSpec,
        )
    }.invokeOnCompletion {
        if (uiState.selectedPromptOption != PromptType.entries[pagerState.currentPage]) {
            onSelectedPromptOptionChanged(PromptType.entries[pagerState.currentPage])
        }
    }
}
```

## ScreenShot
### Before
[Screen_recording_20250522_213720.webm](https://github.com/user-attachments/assets/4a01d3b0-5bf6-4c0b-be57-e38a41edb565)  

### After
[Screen_recording_20250522_220528.webm](https://github.com/user-attachments/assets/fd7e02a2-5ad1-43e0-a580-7ee11e3cb9bb) 