### PR TITLE
Remove redundant license comment header

### DIFF
--- a/app/src/main/java/com/android/developers/androidify/navigation/ListSaver.kt
+++ b/app/src/main/java/com/android/developers/androidify/navigation/ListSaver.kt
@@ -34,22 +34,6 @@ import kotlinx.serialization.encoding.decodeStructure
 import kotlinx.serialization.encoding.encodeStructure
 import kotlinx.serialization.serializer
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 @Composable
 fun <T : Any> rememberMutableStateListOf(vararg elements: T): SnapshotStateList<Any> {
     return rememberSaveable(saver = snapshotStateListSaver(serializableListSaver())) {

--- a/app/src/main/java/com/android/developers/androidify/navigation/MainNavigation.kt
+++ b/app/src/main/java/com/android/developers/androidify/navigation/MainNavigation.kt
@@ -45,21 +45,6 @@ import com.android.developers.androidify.home.AboutScreen
 import com.android.developers.androidify.home.HomeScreen
 import com.android.developers.androidify.theme.transitions.ColorSplashTransitionScreen
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 @ExperimentalMaterial3ExpressiveApi
 @Composable
 fun MainNavigation() {

--- a/app/src/main/java/com/android/developers/androidify/navigation/NavigationRoutes.kt
+++ b/app/src/main/java/com/android/developers/androidify/navigation/NavigationRoutes.kt
@@ -20,21 +20,6 @@ package com.android.developers.androidify.navigation
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 interface NavigationRoute
 
 @Serializable

--- a/core/network/src/main/java/com/android/developers/androidify/RemoteConfigDataSource.kt
+++ b/core/network/src/main/java/com/android/developers/androidify/RemoteConfigDataSource.kt
@@ -20,21 +20,6 @@ import com.google.firebase.remoteconfig.remoteConfig
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 interface RemoteConfigDataSource {
     fun isAppInactive(): Boolean
     fun textModelName(): String

--- a/core/network/src/main/java/com/android/developers/androidify/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/android/developers/androidify/di/NetworkModule.kt
@@ -37,21 +37,6 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 @Module
 @InstallIn(SingletonComponent::class)
 internal class NetworkModule @Inject constructor() {

--- a/core/network/src/main/java/com/android/developers/androidify/vertexai/FirebaseAiDataSource.kt
+++ b/core/network/src/main/java/com/android/developers/androidify/vertexai/FirebaseAiDataSource.kt
@@ -44,22 +44,6 @@ import kotlinx.serialization.json.jsonPrimitive
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 interface FirebaseAiDataSource {
     suspend fun validatePromptHasEnoughInformation(inputPrompt: String): ValidatedDescription
     suspend fun validateImageHasEnoughInformation(image: Bitmap): ValidatedImage

--- a/core/theme/src/main/java/com/android/developers/androidify/theme/Motion.kt
+++ b/core/theme/src/main/java/com/android/developers/androidify/theme/Motion.kt
@@ -23,21 +23,6 @@ import androidx.compose.material3.MotionScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.geometry.Rect
 
-/*
-* Copyright 2022 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 @OptIn(
     ExperimentalMaterial3ExpressiveApi::class,
     ExperimentalSharedTransitionApi::class,

--- a/core/theme/src/main/java/com/android/developers/androidify/theme/SharedElementsConfig.kt
+++ b/core/theme/src/main/java/com/android/developers/androidify/theme/SharedElementsConfig.kt
@@ -66,21 +66,6 @@ import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import com.android.developers.androidify.util.skipToLookaheadPlacement
 import kotlin.math.max
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 sealed interface SharedElementKey {
     object CameraButtonToFullScreenCamera : SharedElementKey
     object CaptureImageToDetails : SharedElementKey

--- a/core/theme/src/main/java/com/android/developers/androidify/theme/components/Backgrounds.kt
+++ b/core/theme/src/main/java/com/android/developers/androidify/theme/components/Backgrounds.kt
@@ -46,21 +46,6 @@ import com.android.developers.androidify.util.backgroundRepeatX
 import com.android.developers.androidify.util.dpToPx
 import com.android.developers.androidify.util.isAtLeastMedium
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 @Composable
 fun SquiggleBackground(
     modifier: Modifier = Modifier,

--- a/core/util/src/main/java/com/android/developers/androidify/util/AdaptivePreview.kt
+++ b/core/util/src/main/java/com/android/developers/androidify/util/AdaptivePreview.kt
@@ -22,22 +22,6 @@ import androidx.compose.ui.tooling.preview.Devices.PIXEL_FOLD
 import androidx.compose.ui.tooling.preview.Devices.PIXEL_TABLET
 import androidx.compose.ui.tooling.preview.Preview
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 @Preview(device = PIXEL_7_PRO, name = "Phone preview")
 annotation class PhonePreview
 

--- a/core/util/src/main/java/com/android/developers/androidify/util/AnimationUtils.kt
+++ b/core/util/src/main/java/com/android/developers/androidify/util/AnimationUtils.kt
@@ -31,21 +31,6 @@ import kotlinx.coroutines.delay
 import java.text.BreakIterator
 import java.text.StringCharacterIterator
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 /**
  * Skips to the end size for a particular composable, skipping through the intermediate animated sizes.
  * Similar to skipToLookaheadSize, but for placement instead.

--- a/core/util/src/main/java/com/android/developers/androidify/util/GraphicsUtils.kt
+++ b/core/util/src/main/java/com/android/developers/androidify/util/GraphicsUtils.kt
@@ -36,21 +36,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.graphics.PathSegment
 import androidx.core.graphics.flatten
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 @Composable
 fun Dp.dpToPx() = with(LocalDensity.current) { this@dpToPx.toPx() }
 

--- a/core/util/src/main/java/com/android/developers/androidify/util/LayoutUtils.kt
+++ b/core/util/src/main/java/com/android/developers/androidify/util/LayoutUtils.kt
@@ -15,22 +15,6 @@
  */
 package com.android.developers.androidify.util
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect

--- a/core/util/src/main/java/com/android/developers/androidify/util/LocalFileProvider.kt
+++ b/core/util/src/main/java/com/android/developers/androidify/util/LocalFileProvider.kt
@@ -31,21 +31,6 @@ import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 interface LocalFileProvider {
     fun saveBitmapToFile(bitmap: Bitmap, file: File): File
     fun getFileFromCache(fileName: String): File

--- a/data/src/main/java/com/android/developers/androidify/data/DataModule.kt
+++ b/data/src/main/java/com/android/developers/androidify/data/DataModule.kt
@@ -32,22 +32,6 @@ import kotlinx.coroutines.Dispatchers
 import javax.inject.Named
 import javax.inject.Singleton
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 @Module
 @InstallIn(SingletonComponent::class)
 internal object DataModule {

--- a/data/src/main/java/com/android/developers/androidify/data/Exceptions.kt
+++ b/data/src/main/java/com/android/developers/androidify/data/Exceptions.kt
@@ -17,21 +17,6 @@ package com.android.developers.androidify.data
 
 import com.android.developers.androidify.model.ImageValidationError as ModelImageValidationError
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 class InsufficientInformationException(errorMessage: String? = null) : Exception(errorMessage)
 
 class ImageValidationException(val imageValidationError: ImageValidationError? = null) : Exception(imageValidationError.toString())

--- a/data/src/main/java/com/android/developers/androidify/data/GeminiNanoGenerationDataSource.kt
+++ b/data/src/main/java/com/android/developers/androidify/data/GeminiNanoGenerationDataSource.kt
@@ -19,22 +19,6 @@ import android.util.Log
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 interface GeminiNanoGenerationDataSource {
     suspend fun initialize()
     suspend fun generatePrompt(prompt: String): String?

--- a/data/src/main/java/com/android/developers/androidify/data/ImageGenerationRepository.kt
+++ b/data/src/main/java/com/android/developers/androidify/data/ImageGenerationRepository.kt
@@ -29,21 +29,6 @@ import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 interface ImageGenerationRepository {
     suspend fun initialize()
     suspend fun generateFromDescription(description: String, skinTone: String): Bitmap

--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/AndroidBotColorPicker.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/AndroidBotColorPicker.kt
@@ -54,22 +54,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 @Composable
 fun AndroidBotColorPicker(
     selectedBotColor: BotColor,

--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationViewModel.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationViewModel.kt
@@ -45,21 +45,6 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Named
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 @HiltViewModel
 class CreationViewModel @Inject constructor(
     val internetConnectivityManager: InternetConnectivityManager,

--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/LoadingScreen.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/LoadingScreen.kt
@@ -80,21 +80,6 @@ import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
 import com.android.developers.androidify.creation.R as CreationR
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 @Composable
 fun LoadingScreen(
     onCancelPress: () -> Unit,

--- a/feature/home/src/main/java/com/android/developers/androidify/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/android/developers/androidify/home/HomeViewModel.kt
@@ -24,21 +24,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 @HiltViewModel
 class HomeViewModel @Inject constructor(val configProvider: ConfigProvider) : ViewModel() {
     private val _state = MutableStateFlow(HomeState())

--- a/feature/results/src/main/java/com/android/developers/androidify/results/ResultsScreen.kt
+++ b/feature/results/src/main/java/com/android/developers/androidify/results/ResultsScreen.kt
@@ -82,21 +82,6 @@ import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.google.accompanist.permissions.shouldShowRationale
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 @Composable
 fun ResultsScreen(
     resultImage: Bitmap,

--- a/feature/results/src/main/java/com/android/developers/androidify/results/ResultsViewModel.kt
+++ b/feature/results/src/main/java/com/android/developers/androidify/results/ResultsViewModel.kt
@@ -32,21 +32,6 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Named
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 @HiltViewModel
 class ResultsViewModel @Inject constructor(
     val imageGenerationRepository: ImageGenerationRepository,

--- a/feature/results/src/main/java/com/android/developers/androidify/results/ShareAction.kt
+++ b/feature/results/src/main/java/com/android/developers/androidify/results/ShareAction.kt
@@ -19,22 +19,6 @@ import android.content.Context
 import android.net.Uri
 import androidx.core.app.ShareCompat
 
-/*
-* Copyright 2025 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 fun shareImage(context: Context, uri: Uri) {
     ShareCompat.IntentBuilder(context)
         .setType("image/jpeg")


### PR DESCRIPTION
# Comment
* I performed a force push with no changes to retrigger the Google CLA check.
* Subsequently, I identified duplicate license headers in multiple files and cleaned them up accordingly.