### PR TITLE
Fix: Preserve PagerState current page on configuration changes

### DIFF
--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationScreen.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationScreen.kt
@@ -402,7 +402,7 @@ private fun MainCreationPane(
         modifier = modifier,
     ) {
         val spatialSpec = MaterialTheme.motionScheme.slowSpatialSpec<Float>()
-        val pagerState = rememberPagerState(0) { PromptType.entries.size }
+        val pagerState = rememberPagerState(uiState.selectedPromptOption.ordinal) { PromptType.entries.size }
         val focusManager = LocalFocusManager.current
         LaunchedEffect(uiState.selectedPromptOption) {
             launch {


### PR DESCRIPTION
This PR fixes an issue where the PagerState in the CreationScreen was resetting to the initial page (index 0) after a configuration change, such as screen rotation. #31 

## Problem 
On screen rotation, PagerState was re-created with the hardcoded initial page index 0, causing the pager to always reset to the first page. This is because the previous state was not preserved across recompositions caused by configuration changes.

## Solution
Instead of hardcoding the initial page index to 0, we now use the current selection `(uiState.selectedPromptOption.ordinal)` to initialize the pager correctly after recomposition or configuration changes.


## Recording 

| Issue | Fix |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/1bf6ed49-cca5-4611-b809-f89108281f61">  | <video src="https://github.com/user-attachments/assets/a1c6f14c-f04a-443b-a4b4-6692c8b0409e">|




