### PR TITLE
refactor: replace KeepScreenOn composable with Modifier.keepScreenOn

### DIFF
--- a/core/util/src/main/java/com/android/developers/androidify/util/LayoutUtils.kt
+++ b/core/util/src/main/java/com/android/developers/androidify/util/LayoutUtils.kt
@@ -17,9 +17,7 @@ package com.android.developers.androidify.util
 
 import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.window.WindowSdkExtensions
 import androidx.window.core.layout.WindowSizeClass
@@ -121,15 +119,4 @@ class FoldablePreviewParametersProvider : PreviewParameterProvider<FoldablePrevi
         FoldablePreviewParameters(supportsTabletop = false, isTabletop = false),
 
     )
-}
-
-@Composable
-fun KeepScreenOn() {
-    val currentView = LocalView.current
-    DisposableEffect(Unit) {
-        currentView.keepScreenOn = true
-        onDispose {
-            currentView.keepScreenOn = false
-        }
-    }
 }

--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/LoadingScreen.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/LoadingScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.Path
 import androidx.compose.ui.graphics.vector.PathParser
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.keepScreenOn
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
@@ -72,7 +73,6 @@ import androidx.compose.ui.unit.dp
 import com.android.developers.androidify.theme.AndroidifyTheme
 import com.android.developers.androidify.theme.components.AndroidifyTopAppBar
 import com.android.developers.androidify.theme.components.PrimaryButton
-import com.android.developers.androidify.util.KeepScreenOn
 import com.android.developers.androidify.util.LargeScreensPreview
 import com.android.developers.androidify.util.SmallPhonePreview
 import com.android.developers.androidify.util.isAtLeastMedium
@@ -85,7 +85,6 @@ fun LoadingScreen(
     onCancelPress: () -> Unit,
     isMediumScreen: Boolean = isAtLeastMedium(),
 ) {
-    KeepScreenOn()
     Scaffold(
         topBar = {
             AndroidifyTopAppBar(isMediumWindowSize = isMediumScreen, aboutEnabled = false)
@@ -108,7 +107,8 @@ fun LoadingScreen(
         },
         containerColor = MaterialTheme.colorScheme.secondary,
         modifier = Modifier
-            .fillMaxSize(),
+            .fillMaxSize()
+            .keepScreenOn(),
     ) { contentPadding ->
         LoadingScreenContents(contentPadding)
     }


### PR DESCRIPTION
Refactors the usage of the KeepScreenOn composable by replacing it with the `Modifier.keepScreenOn` introduced in [Jetpack Compose 1.9.0](https://developer.android.com/jetpack/androidx/releases/compose-ui?hl=pt-br#1.9.0-alpha01)