### PR TITLE
Dagger `@Module` cleanup

### DIFF
--- a/core/util/src/main/java/com/android/developers/androidify/util/LocalFileProvider.kt
+++ b/core/util/src/main/java/com/android/developers/androidify/util/LocalFileProvider.kt
@@ -15,8 +15,8 @@
  */
 package com.android.developers.androidify.util
 
+import android.app.Application
 import android.content.ContentValues
-import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
@@ -46,7 +46,7 @@ interface LocalFileProvider {
 }
 
 @Singleton
-open class LocalFileProviderImpl @Inject constructor(val application: Context) : LocalFileProvider {
+class LocalFileProviderImpl @Inject constructor(private val application: Application) : LocalFileProvider {
 
     override fun saveBitmapToFile(bitmap: Bitmap, file: File): File {
         var outputStream: FileOutputStream? = null

--- a/data/src/main/java/com/android/developers/androidify/data/ConfigProvider.kt
+++ b/data/src/main/java/com/android/developers/androidify/data/ConfigProvider.kt
@@ -16,10 +16,11 @@
 package com.android.developers.androidify.data
 
 import com.android.developers.androidify.RemoteConfigDataSource
+import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ConfigProvider(val remoteConfigDataSource: RemoteConfigDataSource) {
+class ConfigProvider @Inject constructor(val remoteConfigDataSource: RemoteConfigDataSource) {
 
     fun isAppInactive(): Boolean {
         return remoteConfigDataSource.isAppInactive()

--- a/data/src/main/java/com/android/developers/androidify/data/DataModule.kt
+++ b/data/src/main/java/com/android/developers/androidify/data/DataModule.kt
@@ -15,17 +15,16 @@
  */
 package com.android.developers.androidify.data
 
-import android.content.Context
 import com.android.developers.androidify.RemoteConfigDataSource
 import com.android.developers.androidify.RemoteConfigDataSourceImpl
 import com.android.developers.androidify.util.LocalFileProvider
 import com.android.developers.androidify.util.LocalFileProviderImpl
 import com.android.developers.androidify.vertexai.FirebaseAiDataSource
 import com.android.developers.androidify.vertexai.FirebaseAiDataSourceImpl
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -34,71 +33,39 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-internal object DataModule {
+internal abstract class DataModule {
 
-    @Provides
-    @Named("IO")
-    fun ioDispatcher(): CoroutineDispatcher = Dispatchers.IO
+    companion object {
+        @Provides
+        @Named("IO")
+        fun ioDispatcher(): CoroutineDispatcher = Dispatchers.IO
+    }
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideLocalFileProvider(@ApplicationContext appContext: Context): LocalFileProvider =
-        LocalFileProviderImpl(appContext)
+    abstract fun bindsLocalFileProvider(impl: LocalFileProviderImpl): LocalFileProvider
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideRemoteConfigDataSource(): RemoteConfigDataSource = RemoteConfigDataSourceImpl()
+    abstract fun bindsRemoteConfigDataSource(impl: RemoteConfigDataSourceImpl): RemoteConfigDataSource
 
-    @Provides
-    fun provideConfigProvider(remoteConfigDataSource: RemoteConfigDataSource): ConfigProvider =
-        ConfigProvider(remoteConfigDataSource)
-
-    @Provides
+    @Binds
     @Singleton
-    fun providesGeminiNanoDownloader(@ApplicationContext appContext: Context): GeminiNanoDownloader =
-        GeminiNanoDownloader(appContext)
+    abstract fun bindsGeminiNanoDataSource(impl: GeminiNanoGenerationDataSourceImpl): GeminiNanoGenerationDataSource
 
-    @Provides
+    @Binds
     @Singleton
-    fun providesInternetConnectivityManager(@ApplicationContext appContext: Context): InternetConnectivityManager =
-        InternetConnectivityManagerImpl(appContext)
+    abstract fun bindsInternetConnectivityManager(impl: InternetConnectivityManagerImpl): InternetConnectivityManager
 
-    @Provides
+    @Binds
     @Singleton
-    fun providesFirebaseVertexAiDataSource(remoteConfigDataSource: RemoteConfigDataSource): FirebaseAiDataSource =
-        FirebaseAiDataSourceImpl(remoteConfigDataSource)
+    abstract fun bindsFirebaseVertexAiDataSource(impl: FirebaseAiDataSourceImpl): FirebaseAiDataSource
 
-    @Provides
+    @Binds
     @Singleton
-    fun providesTextGenerationRepository(
-        remoteConfigDataSource: RemoteConfigDataSource,
-        geminiNanoDataSource: GeminiNanoGenerationDataSource,
-        firebaseAiDataSource: FirebaseAiDataSource,
-    ): TextGenerationRepository =
-        TextGenerationRepositoryImpl(
-            remoteConfigDataSource,
-            geminiNanoDataSource,
-            firebaseAiDataSource,
-        )
+    abstract fun bindsTextGenerationRepository(impl: TextGenerationRepositoryImpl): TextGenerationRepository
 
-    @Provides
+    @Binds
     @Singleton
-    fun providesGeminiNanoDataSource(geminiNanoDownloader: GeminiNanoDownloader): GeminiNanoGenerationDataSource =
-        GeminiNanoGenerationDataSourceImpl(geminiNanoDownloader)
-
-    @Provides
-    @Singleton
-    fun imageGenerationRepository(
-        remoteConfigDataSource: RemoteConfigDataSource,
-        localFileProvider: LocalFileProvider,
-        internetConnectivityManager: InternetConnectivityManager,
-        firebaseAiDataSource: FirebaseAiDataSource,
-        geminiNanoGenerationDataSource: GeminiNanoGenerationDataSource,
-    ): ImageGenerationRepository = ImageGenerationRepositoryImpl(
-        remoteConfigDataSource = remoteConfigDataSource,
-        localFileProvider = localFileProvider,
-        geminiNanoDataSource = geminiNanoGenerationDataSource,
-        internetConnectivityManager = internetConnectivityManager,
-        firebaseAiDataSource = firebaseAiDataSource,
-    )
+    abstract fun bindsImageGenerationRepository(impl: ImageGenerationRepositoryImpl): ImageGenerationRepository
 }

--- a/data/src/main/java/com/android/developers/androidify/data/GeminiNanoDownloader.kt
+++ b/data/src/main/java/com/android/developers/androidify/data/GeminiNanoDownloader.kt
@@ -15,17 +15,18 @@
  */
 package com.android.developers.androidify.data
 
-import android.content.Context
+import android.app.Application
 import android.util.Log
 import com.google.ai.edge.aicore.DownloadCallback
 import com.google.ai.edge.aicore.DownloadConfig
 import com.google.ai.edge.aicore.GenerativeAIException
 import com.google.ai.edge.aicore.GenerativeModel
 import com.google.ai.edge.aicore.generationConfig
+import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class GeminiNanoDownloader(val applicationContext: Context) {
+class GeminiNanoDownloader @Inject constructor(private val application: Application) {
     var generativeModel: GenerativeModel? = null
         private set
 
@@ -68,7 +69,7 @@ class GeminiNanoDownloader(val applicationContext: Context) {
         val downloadConfig = DownloadConfig(downloadCallback)
 
         val generationConfig = generationConfig {
-            context = applicationContext
+            context = application
             temperature = 0.2f
             topK = 16
             maxOutputTokens = 256

--- a/data/src/main/java/com/android/developers/androidify/data/GeminiNanoGenerationDataSource.kt
+++ b/data/src/main/java/com/android/developers/androidify/data/GeminiNanoGenerationDataSource.kt
@@ -25,7 +25,7 @@ interface GeminiNanoGenerationDataSource {
 }
 
 @Singleton
-class GeminiNanoGenerationDataSourceImpl @Inject constructor(val downloader: GeminiNanoDownloader) :
+internal class GeminiNanoGenerationDataSourceImpl @Inject constructor(private val downloader: GeminiNanoDownloader) :
     GeminiNanoGenerationDataSource {
 
     override suspend fun initialize() {

--- a/data/src/main/java/com/android/developers/androidify/data/ImageGenerationRepository.kt
+++ b/data/src/main/java/com/android/developers/androidify/data/ImageGenerationRepository.kt
@@ -19,7 +19,6 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.util.Log
-import com.android.developers.androidify.RemoteConfigDataSource
 import com.android.developers.androidify.model.ValidatedDescription
 import com.android.developers.androidify.model.ValidatedImage
 import com.android.developers.androidify.util.LocalFileProvider
@@ -40,11 +39,10 @@ interface ImageGenerationRepository {
 
 @Singleton
 internal class ImageGenerationRepositoryImpl @Inject constructor(
-    val remoteConfigDataSource: RemoteConfigDataSource,
-    val localFileProvider: LocalFileProvider,
-    val internetConnectivityManager: InternetConnectivityManager,
-    val geminiNanoDataSource: GeminiNanoGenerationDataSource,
-    val firebaseAiDataSource: FirebaseAiDataSource,
+    private val localFileProvider: LocalFileProvider,
+    private val internetConnectivityManager: InternetConnectivityManager,
+    private val geminiNanoDataSource: GeminiNanoGenerationDataSource,
+    private val firebaseAiDataSource: FirebaseAiDataSource,
 ) : ImageGenerationRepository {
 
     override suspend fun initialize() {

--- a/data/src/main/java/com/android/developers/androidify/data/InternetConnectivityManager.kt
+++ b/data/src/main/java/com/android/developers/androidify/data/InternetConnectivityManager.kt
@@ -15,10 +15,10 @@
  */
 package com.android.developers.androidify.data
 
+import android.app.Application
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -27,11 +27,11 @@ interface InternetConnectivityManager {
 }
 
 @Singleton
-class InternetConnectivityManagerImpl @Inject constructor(@ApplicationContext val context: Context) :
+internal class InternetConnectivityManagerImpl @Inject constructor(private val application: Application) :
     InternetConnectivityManager {
     override fun isInternetAvailable(): Boolean {
         val connectivityManager =
-            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            application.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         val network = connectivityManager.activeNetwork ?: return false
         val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
         return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)

--- a/data/src/main/java/com/android/developers/androidify/data/TextGenerationRepository.kt
+++ b/data/src/main/java/com/android/developers/androidify/data/TextGenerationRepository.kt
@@ -27,9 +27,9 @@ interface TextGenerationRepository {
 
 @Singleton
 class TextGenerationRepositoryImpl @Inject constructor(
-    val remoteConfigDataSource: RemoteConfigDataSource,
-    val geminiNanoDataSource: GeminiNanoGenerationDataSource,
-    val firebaseAiDataSource: FirebaseAiDataSource,
+    private val remoteConfigDataSource: RemoteConfigDataSource,
+    private val geminiNanoDataSource: GeminiNanoGenerationDataSource,
+    private val firebaseAiDataSource: FirebaseAiDataSource,
 ) : TextGenerationRepository {
 
     private var currentPrompts: List<String>? = null


### PR DESCRIPTION
- Replace unnecessary `@Provides` with `@Binds`
- Add missing `@Inject constructor`s
- Lower visibility of classes and fields where modularization permits
- Convert raw `Context` and `@ApplicationContext` usages with explicit `Application`