### PR TITLE
Refactor: Organize Home screen components and states

### DIFF
--- a/app/src/main/java/com/android/developers/androidify/navigation/MainNavigation.kt
+++ b/app/src/main/java/com/android/developers/androidify/navigation/MainNavigation.kt
@@ -29,19 +29,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.unit.IntOffset
-import androidx.lifecycle.viewmodel.navigation3.ViewModelStoreNavEntryDecorator
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
-import androidx.navigation3.runtime.SavedStateNavEntryDecorator
 import androidx.navigation3.runtime.entry
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
-import androidx.navigation3.ui.SceneSetupNavEntryDecorator
+import com.android.developers.androidify.about.AboutScreen
 import com.android.developers.androidify.camera.CameraPreviewScreen
 import com.android.developers.androidify.creation.CreationScreen
-import com.android.developers.androidify.home.AboutScreen
 import com.android.developers.androidify.home.HomeScreen
 import com.android.developers.androidify.theme.transitions.ColorSplashTransitionScreen
 
@@ -49,13 +45,11 @@ import com.android.developers.androidify.theme.transitions.ColorSplashTransition
 @Composable
 fun MainNavigation() {
     val backStack = rememberMutableStateListOf<NavigationRoute>(Home)
-    var positionReveal by remember {
-        mutableStateOf(IntOffset.Zero)
-    }
-    var showSplash by remember {
-        mutableStateOf(false)
-    }
+
+    var positionReveal by remember { mutableStateOf(IntOffset.Zero) }
+    var showSplash by remember { mutableStateOf(false) }
     val motionScheme = MaterialTheme.motionScheme
+
     NavDisplay(
         backStack = backStack,
         onBack = { backStack.removeLastOrNull() },
@@ -78,7 +72,7 @@ fun MainNavigation() {
             )
         },
         entryProvider = entryProvider {
-            entry<Home> { entry ->
+            entry<Home> {
                 HomeScreen(
                     onClickLetsGo = { positionOffset ->
                         showSplash = true
@@ -115,9 +109,7 @@ fun MainNavigation() {
             }
             entry<About> {
                 AboutScreen(
-                    onBackPressed = {
-                        backStack.removeLastOrNull()
-                    },
+                    onBackPressed = { backStack.removeLastOrNull() },
                 )
             }
         },

--- a/feature/home/src/main/java/com/android/developers/androidify/about/AboutScreen.kt
+++ b/feature/home/src/main/java/com/android/developers/androidify/about/AboutScreen.kt
@@ -15,7 +15,7 @@
  */
 @file:OptIn(ExperimentalSharedTransitionApi::class, ExperimentalMaterial3ExpressiveApi::class)
 
-package com.android.developers.androidify.home
+package com.android.developers.androidify.about
 
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.background
@@ -55,6 +55,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
+import com.android.developers.androidify.home.R
 import com.android.developers.androidify.theme.AndroidifyTheme
 import com.android.developers.androidify.theme.LocalSharedTransitionScope
 import com.android.developers.androidify.theme.SharedElementContextPreview
@@ -65,22 +66,6 @@ import com.android.developers.androidify.util.LargeScreensPreview
 import com.android.developers.androidify.util.PhonePreview
 import com.android.developers.androidify.util.isAtLeastMedium
 
-@PhonePreview
-@Composable
-private fun AboutPreviewCompact() {
-    SharedElementContextPreview {
-        AboutScreen(isMediumWindowSize = false) {}
-    }
-}
-
-@LargeScreensPreview
-@Composable
-private fun AboutPreviewLargeScreens() {
-    SharedElementContextPreview {
-        AboutScreen(isMediumWindowSize = true) {}
-    }
-}
-
 @Composable
 fun AboutScreen(
     isMediumWindowSize: Boolean = isAtLeastMedium(),
@@ -88,11 +73,13 @@ fun AboutScreen(
 ) {
     val sharedElementScope = LocalSharedTransitionScope.current
     val navScope = LocalNavAnimatedContentScope.current
+
     with(sharedElementScope) {
         Scaffold(
             topBar = {
                 IconButton(
-                    modifier = Modifier.safeDrawingPadding()
+                    modifier = Modifier
+                        .safeDrawingPadding()
                         .padding(16.dp),
                     shape = CircleShape,
                     colors = IconButtonDefaults.iconButtonColors(
@@ -208,16 +195,12 @@ private fun FooterButtons() {
     val uriHandler = LocalUriHandler.current
     Row {
         SecondaryOutlinedButton(
-            onClick = {
-                uriHandler.openUri("https://policies.google.com/terms")
-            },
+            onClick = { uriHandler.openUri("https://policies.google.com/terms") },
             buttonText = stringResource(R.string.terms),
         )
         Spacer(modifier = Modifier.size(16.dp))
         SecondaryOutlinedButton(
-            onClick = {
-                uriHandler.openUri("https://policies.google.com/privacy")
-            },
+            onClick = { uriHandler.openUri("https://policies.google.com/privacy") },
             buttonText = stringResource(R.string.privacy),
         )
     }
@@ -232,7 +215,7 @@ private fun AboutMessage(textStyle: TextStyle = MaterialTheme.typography.bodyLar
 }
 
 @Composable
-fun BulletPoint(
+private fun BulletPoint(
     bulletText: String,
     title: String,
     text: String,
@@ -269,10 +252,36 @@ fun BulletPoint(
     }
 }
 
+@PhonePreview
+@Composable
+private fun AboutPreviewCompact() {
+    SharedElementContextPreview {
+        AboutScreen(
+            isMediumWindowSize = false,
+            onBackPressed = {},
+        )
+    }
+}
+
+@LargeScreensPreview
+@Composable
+private fun AboutPreviewLargeScreens() {
+    SharedElementContextPreview {
+        AboutScreen(
+            isMediumWindowSize = true,
+            onBackPressed = {},
+        )
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun BulletPointPreview() {
     AndroidifyTheme {
-        BulletPoint("1", "Photo", "Take a photo")
+        BulletPoint(
+            bulletText = "1",
+            title = "Photo",
+            text = "Take a photo",
+        )
     }
 }

--- a/feature/home/src/main/java/com/android/developers/androidify/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/android/developers/androidify/home/HomeScreen.kt
@@ -15,140 +15,75 @@
  */
 package com.android.developers.androidify.home
 
-import androidx.annotation.OptIn
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.focusable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicText
-import androidx.compose.foundation.text.InlineTextContent
-import androidx.compose.foundation.text.TextAutoSize
-import androidx.compose.foundation.text.appendInlineContent
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonColors
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedIconButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.onLayoutRectChanged
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.Placeholder
-import androidx.compose.ui.text.PlaceholderVerticalAlign
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.media3.common.MediaItem
-import androidx.media3.common.Player
-import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.ui.compose.PlayerSurface
-import androidx.media3.ui.compose.SURFACE_TYPE_TEXTURE_VIEW
-import androidx.media3.ui.compose.state.rememberPlayPauseButtonState
-import coil3.compose.AsyncImage
-import com.android.developers.androidify.theme.Blue
+import com.android.developers.androidify.home.component.CompactPager
+import com.android.developers.androidify.home.component.HomePageButton
+import com.android.developers.androidify.home.component.VideoPlayerRotatedCard
+import com.android.developers.androidify.home.content.InactiveAppHomeContent
+import com.android.developers.androidify.home.content.MainHomeContent
 import com.android.developers.androidify.theme.SharedElementContextPreview
-import com.android.developers.androidify.theme.components.AndroidifyTopAppBar
 import com.android.developers.androidify.theme.components.AndroidifyTranslucentTopAppBar
 import com.android.developers.androidify.theme.components.SquiggleBackground
 import com.android.developers.androidify.util.LargeScreensPreview
 import com.android.developers.androidify.util.PhonePreview
 import com.android.developers.androidify.util.isAtLeastMedium
-import com.android.developers.androidify.theme.R as ThemeR
 
 @ExperimentalMaterial3ExpressiveApi
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun HomeScreen(
     homeScreenViewModel: HomeViewModel = hiltViewModel(),
     isMediumWindowSize: Boolean = isAtLeastMedium(),
-    onClickLetsGo: (IntOffset) -> Unit = {},
-    onAboutClicked: () -> Unit = {},
+    onClickLetsGo: (IntOffset) -> Unit,
+    onAboutClicked: () -> Unit,
 ) {
-    val state = homeScreenViewModel.state.collectAsStateWithLifecycle()
-    if (!state.value.isAppActive) {
-        AppInactiveScreen()
-    } else {
+    val state by homeScreenViewModel.state.collectAsStateWithLifecycle()
+
+    if (state.isAppActive) {
         HomeScreenContents(
-            state.value.videoLink,
-            state.value.dancingDroidLink,
-            isMediumWindowSize,
-            onClickLetsGo,
-            onAboutClicked,
+            videoLink = state.videoLink,
+            dancingBotLink = state.dancingDroidLink,
+            isMediumWindowSize = isMediumWindowSize,
+            onClickLetsGo = onClickLetsGo,
+            onAboutClicked = onAboutClicked,
         )
+    } else {
+        InactiveAppHomeContent()
     }
 }
 
 @Composable
-fun HomeScreenContents(
+internal fun HomeScreenContents(
     videoLink: String?,
     dancingBotLink: String?,
     isMediumWindowSize: Boolean,
     onClickLetsGo: (IntOffset) -> Unit,
     onAboutClicked: () -> Unit,
 ) {
+    var positionButtonClick by remember { mutableStateOf(IntOffset.Zero) }
+
     Box {
         SquiggleBackground()
-        var positionButtonClick by remember {
-            mutableStateOf(IntOffset.Zero)
-        }
+
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -167,7 +102,7 @@ fun HomeScreenContents(
                         modifier = Modifier.weight(0.8f),
                     ) {
                         VideoPlayerRotatedCard(
-                            videoLink,
+                            videoLink = videoLink,
                             modifier = Modifier
                                 .padding(32.dp)
                                 .align(Alignment.Center),
@@ -178,7 +113,7 @@ fun HomeScreenContents(
                             .weight(1.2f)
                             .align(Alignment.CenterVertically),
                     ) {
-                        MainHomeContent(dancingBotLink)
+                        MainHomeContent(dancingBotLink = dancingBotLink)
                         HomePageButton(
                             modifier = Modifier
                                 .onLayoutRectChanged {
@@ -188,140 +123,19 @@ fun HomeScreenContents(
                                 .padding(bottom = 16.dp)
                                 .height(64.dp)
                                 .width(220.dp),
-                            onClick = {
-                                onClickLetsGo(positionButtonClick)
-                            },
+                            onClick = { onClickLetsGo(positionButtonClick) },
                         )
                     }
                 }
             } else {
                 CompactPager(
-                    videoLink,
-                    dancingBotLink,
-                    onClickLetsGo,
-                    onAboutClicked,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun CompactPager(
-    videoLink: String?,
-    dancingBotLink: String?,
-    onClick: (IntOffset) -> Unit,
-    onAboutClicked: () -> Unit,
-) {
-    val pagerState = rememberPagerState(pageCount = { 2 })
-
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        AndroidifyTopAppBar(
-            aboutEnabled = true,
-            onAboutClicked = onAboutClicked,
-        )
-        HorizontalPager(
-            state = pagerState,
-            modifier = Modifier.weight(.8f),
-            beyondViewportPageCount = 1,
-        ) { page ->
-            if (page == 0) {
-                MainHomeContent(
+                    videoLink = videoLink,
                     dancingBotLink = dancingBotLink,
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .align(Alignment.CenterHorizontally),
-                )
-            } else {
-                Box(modifier = Modifier.fillMaxSize()) {
-                    VideoPlayerRotatedCard(
-                        videoLink = videoLink,
-                        modifier = Modifier
-                            .padding(horizontal = 32.dp)
-                            .align(Alignment.Center),
-                    )
-                }
-            }
-        }
-        Row(
-            modifier = Modifier
-                .weight(.1f)
-                .fillMaxWidth(),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            repeat(pagerState.pageCount) { iteration ->
-                val isCurrent by remember { derivedStateOf<Boolean> { pagerState.currentPage == iteration } }
-                val animatedColor by animateColorAsState(
-                    if (isCurrent) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onTertiary,
-                    label = "animatedFirstColor",
-                )
-
-                Box(
-                    modifier = Modifier
-                        .padding(2.dp)
-                        .clip(RoundedCornerShape(size = 16.dp))
-                        .animateContentSize()
-                        .background(
-                            color = animatedColor,
-                            shape = RoundedCornerShape(size = 16.dp),
-                        )
-                        .height(16.dp)
-                        .width(if (isCurrent) 40.dp else 16.dp),
+                    onClick = onClickLetsGo,
+                    onAboutClicked = onAboutClicked,
                 )
             }
         }
-        Spacer(modifier = Modifier.size(12.dp))
-        var buttonPosition by remember {
-            mutableStateOf(IntOffset.Zero)
-        }
-        HomePageButton(
-            modifier = Modifier
-                .onLayoutRectChanged {
-                    buttonPosition = it.boundsInWindow.center
-                }
-                .padding(bottom = 16.dp)
-                .height(64.dp)
-                .width(220.dp),
-            colors = ButtonDefaults.buttonColors()
-                .copy(containerColor = Blue),
-            onClick = {
-                onClick(buttonPosition)
-            },
-        )
-    }
-}
-
-@Composable
-private fun VideoPlayerRotatedCard(
-    videoLink: String?,
-    modifier: Modifier = Modifier,
-) {
-    val aspectRatio = 280f / 380f
-    val videoInstructionText = stringResource(R.string.instruction_video_transcript)
-    Box(
-        modifier = modifier
-            .focusable()
-            .semantics { contentDescription = videoInstructionText }
-            .aspectRatio(aspectRatio)
-            .rotate(-3f)
-            .shadow(elevation = 8.dp, shape = MaterialTheme.shapes.large)
-            .background(
-                color = Color.White,
-                shape = MaterialTheme.shapes.large,
-            ),
-    ) {
-        VideoPlayer(
-            videoLink,
-            modifier = Modifier
-                .aspectRatio(aspectRatio)
-                .align(Alignment.Center)
-                .clip(MaterialTheme.shapes.large)
-                .clipToBounds(),
-        )
     }
 }
 
@@ -353,242 +167,4 @@ private fun HomeScreenLargeScreensPreview() {
             onAboutClicked = {},
         )
     }
-}
-
-@Composable
-private fun MainHomeContent(
-    dancingBotLink: String?,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier,
-    ) {
-        DecorativeSquiggleLimeGreen()
-        DancingBotHeadlineText(
-            dancingBotLink,
-            modifier = Modifier.weight(1f),
-        )
-        DecorativeSquiggleLightGreen()
-    }
-}
-
-@Composable
-private fun ColumnScope.DecorativeSquiggleLightGreen() {
-    val infiniteAnimation = rememberInfiniteTransition()
-    val rotationAnimation = infiniteAnimation.animateFloat(
-        0f,
-        720f,
-        animationSpec = infiniteRepeatable(
-            tween(12000, easing = LinearEasing),
-            repeatMode = RepeatMode.Reverse,
-        ),
-    )
-    Image(
-        painter = rememberVectorPainter(
-            ImageVector.vectorResource(ThemeR.drawable.decorative_squiggle_2),
-        ),
-        contentDescription = null, // decorative element
-        modifier = Modifier
-            .padding(start = 60.dp)
-            .size(60.dp)
-            .align(Alignment.Start)
-            .graphicsLayer {
-                rotationZ = rotationAnimation.value
-            },
-    )
-}
-
-@Composable
-private fun ColumnScope.DecorativeSquiggleLimeGreen() {
-    val infiniteAnimation = rememberInfiniteTransition()
-    val rotationAnimation = infiniteAnimation.animateFloat(
-        0f,
-        -720f,
-        animationSpec = infiniteRepeatable(
-            tween(24000, easing = LinearEasing),
-            repeatMode = RepeatMode.Reverse,
-        ),
-    )
-    Image(
-        painter = rememberVectorPainter(
-            ImageVector.vectorResource(ThemeR.drawable.decorative_squiggle),
-        ),
-        contentDescription = null, // decorative element
-        modifier = Modifier
-            .padding(end = 80.dp)
-            .size(60.dp)
-            .align(Alignment.End)
-            .graphicsLayer {
-                rotationZ = rotationAnimation.value
-            },
-
-    )
-}
-
-@Preview
-@Composable
-private fun HomePageButton(
-    modifier: Modifier = Modifier,
-    colors: ButtonColors = ButtonDefaults.buttonColors().copy(containerColor = Blue),
-    onClick: () -> Unit = {},
-) {
-    val style = MaterialTheme.typography.titleLarge.copy(
-        fontWeight = FontWeight(700),
-        letterSpacing = .15f.sp,
-    )
-
-    Button(
-        onClick = onClick,
-        modifier = modifier,
-        colors = colors,
-    ) {
-        Text(
-            stringResource(R.string.home_button_label),
-            style = style,
-        )
-    }
-}
-
-@Composable
-private fun DancingBot(
-    dancingBotLink: String?,
-    modifier: Modifier,
-) {
-    AsyncImage(
-        model = dancingBotLink,
-        modifier = modifier,
-        contentDescription = null,
-    )
-}
-
-@Composable
-private fun DancingBotHeadlineText(
-    dancingBotLink: String?,
-    modifier: Modifier = Modifier,
-) {
-    Box(modifier = modifier) {
-        val animatedBot = "animatedBot"
-        val text = buildAnnotatedString {
-            append(stringResource(R.string.customize_your_own))
-            // Attach "animatedBot" annotation on the placeholder
-            appendInlineContent(animatedBot)
-            append(stringResource(R.string.into_an_android_bot))
-        }
-        var placeHolderSize by remember {
-            mutableStateOf(220.sp)
-        }
-        val inlineContent = mapOf(
-            Pair(
-                animatedBot,
-                InlineTextContent(
-                    Placeholder(
-                        width = placeHolderSize,
-                        height = placeHolderSize,
-                        placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter,
-                    ),
-                ) {
-                    DancingBot(
-                        dancingBotLink,
-                        modifier = Modifier
-                            .padding(top = 32.dp)
-                            .fillMaxSize(),
-                    )
-                },
-            ),
-        )
-        BasicText(
-            text,
-            modifier = Modifier
-                .align(Alignment.Center)
-                .padding(bottom = 16.dp, start = 16.dp, end = 16.dp),
-            style = MaterialTheme.typography.titleLarge,
-            autoSize = TextAutoSize.StepBased(maxFontSize = 220.sp),
-            maxLines = 5,
-            onTextLayout = { result ->
-                placeHolderSize = result.layoutInput.style.fontSize * 3.5f
-            },
-            inlineContent = inlineContent,
-        )
-    }
-}
-
-@OptIn(UnstableApi::class) // New Media3 Compose artifact is currently experimental
-@Composable
-private fun VideoPlayer(
-    videoLink: String?,
-    modifier: Modifier = Modifier,
-) {
-    if (LocalInspectionMode.current) return // Layoutlib does not support ExoPlayer
-
-    val context = LocalContext.current
-    var player by remember { mutableStateOf<Player?>(null) }
-    LifecycleStartEffect(videoLink) {
-        if (videoLink != null) {
-            player = ExoPlayer.Builder(context).build().apply {
-                setMediaItem(MediaItem.fromUri(videoLink))
-                repeatMode = Player.REPEAT_MODE_ONE
-                prepare()
-            }
-        }
-        onStopOrDispose {
-            player?.release()
-            player = null
-        }
-    }
-
-    var videoFullyOnScreen by remember { mutableStateOf(false) }
-    Box(
-        Modifier
-            .background(MaterialTheme.colorScheme.surfaceContainerLowest)
-            .onVisibilityChanged(
-                containerWidth = LocalView.current.width,
-                containerHeight = LocalView.current.height,
-            ) { fullyVisible -> videoFullyOnScreen = fullyVisible }
-            .then(modifier),
-    ) {
-        player?.let { currentPlayer ->
-            LaunchedEffect(videoFullyOnScreen) {
-                if (videoFullyOnScreen) currentPlayer.play() else currentPlayer.pause()
-            }
-
-            // Render the video
-            PlayerSurface(currentPlayer, surfaceType = SURFACE_TYPE_TEXTURE_VIEW)
-
-            // Show a play / pause button
-            val playPauseButtonState = rememberPlayPauseButtonState(currentPlayer)
-            OutlinedIconButton(
-                onClick = playPauseButtonState::onClick,
-                enabled = playPauseButtonState.isEnabled,
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(16.dp),
-                colors = IconButtonDefaults.outlinedIconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
-                    disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
-                ),
-            ) {
-                val icon =
-                    if (playPauseButtonState.showPlay) R.drawable.rounded_play_arrow_24 else R.drawable.rounded_pause_24
-                val contentDescription =
-                    if (playPauseButtonState.showPlay) R.string.play else R.string.pause
-                Icon(
-                    painterResource(icon),
-                    stringResource(contentDescription),
-                )
-            }
-        }
-    }
-}
-
-fun Modifier.onVisibilityChanged(
-    containerWidth: Int,
-    containerHeight: Int,
-    onChanged: (visible: Boolean) -> Unit,
-) = this then Modifier.onLayoutRectChanged(100, 0) { layoutBounds ->
-    onChanged(
-        layoutBounds.boundsInRoot.top > 0 &&
-            layoutBounds.boundsInRoot.bottom < containerHeight &&
-            layoutBounds.boundsInRoot.left > 0 &&
-            layoutBounds.boundsInRoot.right < containerWidth,
-    )
 }

--- a/feature/home/src/main/java/com/android/developers/androidify/home/component/CompactPager.kt
+++ b/feature/home/src/main/java/com/android/developers/androidify/home/component/CompactPager.kt
@@ -1,0 +1,122 @@
+package com.android.developers.androidify.home.component
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.onLayoutRectChanged
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import com.android.developers.androidify.home.content.MainHomeContent
+import com.android.developers.androidify.theme.components.AndroidifyTopAppBar
+
+@Composable
+internal fun CompactPager(
+    videoLink: String?,
+    dancingBotLink: String?,
+    onClick: (IntOffset) -> Unit,
+    onAboutClicked: () -> Unit,
+) {
+    val pagerState: PagerState = rememberPagerState(
+        initialPage = 0,
+        pageCount = { 2 },
+    )
+    var buttonPosition by remember { mutableStateOf(IntOffset.Zero) }
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        AndroidifyTopAppBar(
+            aboutEnabled = true,
+            onAboutClicked = onAboutClicked,
+        )
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.weight(.8f),
+            beyondViewportPageCount = 1,
+        ) { page ->
+            if (page == 0) {
+                MainHomeContent(
+                    dancingBotLink = dancingBotLink,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .align(Alignment.CenterHorizontally),
+                )
+            } else {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    VideoPlayerRotatedCard(
+                        videoLink = videoLink,
+                        modifier = Modifier
+                            .padding(horizontal = 32.dp)
+                            .align(Alignment.Center),
+                    )
+                }
+            }
+        }
+        Row(
+            modifier = Modifier
+                .weight(.1f)
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            repeat(pagerState.pageCount) { iteration ->
+
+                val isCurrent by remember { derivedStateOf { pagerState.currentPage == iteration } }
+                val animatedColor by animateColorAsState(
+                    targetValue = if (isCurrent) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onTertiary,
+                    label = "animatedFirstColor",
+                )
+
+                Box(
+                    modifier = Modifier
+                        .padding(2.dp)
+                        .clip(RoundedCornerShape(size = 16.dp))
+                        .animateContentSize()
+                        .background(
+                            color = animatedColor,
+                            shape = RoundedCornerShape(size = 16.dp),
+                        )
+                        .height(16.dp)
+                        .width(if (isCurrent) 40.dp else 16.dp),
+                )
+            }
+        }
+        Spacer(modifier = Modifier.size(12.dp))
+        HomePageButton(
+            modifier = Modifier
+                .onLayoutRectChanged {
+                    buttonPosition = it.boundsInWindow.center
+                }
+                .padding(bottom = 16.dp)
+                .height(64.dp)
+                .width(220.dp),
+            onClick = { onClick(buttonPosition) },
+        )
+    }
+}

--- a/feature/home/src/main/java/com/android/developers/androidify/home/component/HomePageButton.kt
+++ b/feature/home/src/main/java/com/android/developers/androidify/home/component/HomePageButton.kt
@@ -1,0 +1,37 @@
+package com.android.developers.androidify.home.component
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.sp
+import com.android.developers.androidify.home.R
+import com.android.developers.androidify.theme.Blue
+
+@Preview
+@Composable
+internal fun HomePageButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+) {
+    val style = MaterialTheme.typography.titleLarge.copy(
+        fontWeight = FontWeight(700),
+        letterSpacing = .15f.sp,
+    )
+
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        colors = ButtonDefaults.buttonColors().copy(containerColor = Blue),
+    ) {
+        Text(
+            text = stringResource(R.string.home_button_label),
+            style = style,
+        )
+    }
+}

--- a/feature/home/src/main/java/com/android/developers/androidify/home/component/VideoPlayerRotatedCard.kt
+++ b/feature/home/src/main/java/com/android/developers/androidify/home/component/VideoPlayerRotatedCard.kt
@@ -1,0 +1,149 @@
+package com.android.developers.androidify.home.component
+
+import androidx.annotation.OptIn
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedIconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LifecycleStartEffect
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.compose.PlayerSurface
+import androidx.media3.ui.compose.SURFACE_TYPE_TEXTURE_VIEW
+import androidx.media3.ui.compose.state.rememberPlayPauseButtonState
+import com.android.developers.androidify.home.R
+import com.android.developers.androidify.home.util.onVisibilityChanged
+
+@Composable
+internal fun VideoPlayerRotatedCard(
+    videoLink: String?,
+    modifier: Modifier = Modifier,
+) {
+    val aspectRatio: Float = 280f / 380f
+    val videoInstructionText = stringResource(R.string.instruction_video_transcript)
+
+    Box(
+        modifier = modifier
+            .focusable()
+            .semantics { contentDescription = videoInstructionText }
+            .aspectRatio(ratio = aspectRatio)
+            .rotate(degrees = -3f)
+            .shadow(
+                elevation = 8.dp,
+                shape = MaterialTheme.shapes.large,
+            )
+            .background(
+                color = Color.White,
+                shape = MaterialTheme.shapes.large,
+            ),
+    ) {
+        VideoPlayer(
+            videoLink = videoLink,
+            modifier = Modifier
+                .aspectRatio(aspectRatio)
+                .align(Alignment.Center)
+                .clip(MaterialTheme.shapes.large)
+                .clipToBounds(),
+        )
+    }
+}
+
+@OptIn(UnstableApi::class) // New Media3 Compose artifact is currently experimental
+@Composable
+private fun VideoPlayer(
+    videoLink: String?,
+    modifier: Modifier = Modifier,
+) {
+    if (LocalInspectionMode.current) return // Layoutlib does not support ExoPlayer
+
+    val context = LocalContext.current
+    var player by remember { mutableStateOf<Player?>(null) }
+    var videoFullyOnScreen by remember { mutableStateOf(false) }
+
+    LifecycleStartEffect(videoLink) {
+        if (videoLink != null) {
+            player = ExoPlayer.Builder(context).build().apply {
+                setMediaItem(MediaItem.fromUri(videoLink))
+                repeatMode = Player.REPEAT_MODE_ONE
+                prepare()
+            }
+        }
+        onStopOrDispose {
+            player?.release()
+            player = null
+        }
+    }
+
+    Box(
+        Modifier
+            .background(MaterialTheme.colorScheme.surfaceContainerLowest)
+            .onVisibilityChanged(
+                containerWidth = LocalView.current.width,
+                containerHeight = LocalView.current.height,
+            ) { fullyVisible ->
+                videoFullyOnScreen = fullyVisible
+            }
+            .then(modifier),
+    ) {
+        player?.let { currentPlayer ->
+            LaunchedEffect(videoFullyOnScreen) {
+                if (videoFullyOnScreen) currentPlayer.play() else currentPlayer.pause()
+            }
+
+            // Render the video
+            PlayerSurface(currentPlayer, surfaceType = SURFACE_TYPE_TEXTURE_VIEW)
+
+            // Show a play / pause button
+            val playPauseButtonState = rememberPlayPauseButtonState(currentPlayer)
+            OutlinedIconButton(
+                onClick = playPauseButtonState::onClick,
+                enabled = playPauseButtonState.isEnabled,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp),
+                colors = IconButtonDefaults.outlinedIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+                    disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+                ),
+            ) {
+                val icon =
+                    if (playPauseButtonState.showPlay) R.drawable.rounded_play_arrow_24 else R.drawable.rounded_pause_24
+                val contentDescription =
+                    if (playPauseButtonState.showPlay) R.string.play else R.string.pause
+
+                Icon(
+                    painterResource(icon),
+                    stringResource(contentDescription),
+                )
+            }
+        }
+    }
+}

--- a/feature/home/src/main/java/com/android/developers/androidify/home/content/InactiveAppHomeContent.kt
+++ b/feature/home/src/main/java/com/android/developers/androidify/home/content/InactiveAppHomeContent.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.android.developers.androidify.home
+package com.android.developers.androidify.home.content
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -32,29 +32,20 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.android.developers.androidify.home.R
 import com.android.developers.androidify.theme.SharedElementContextPreview
 import com.android.developers.androidify.theme.components.AndroidifyTopAppBar
 
-@Preview
 @Composable
-fun AppInactivePreview() {
-    SharedElementContextPreview {
-        AppInactiveScreen()
-    }
-}
-
-@Composable
-fun AppInactiveScreen() {
+internal fun InactiveAppHomeContent() {
     Scaffold(
-        topBar = {
-            AndroidifyTopAppBar()
-        },
-    ) { padding ->
+        topBar = { AndroidifyTopAppBar() },
+    ) { paddingValues ->
         Column(
             modifier = Modifier
                 .background(MaterialTheme.colorScheme.secondary)
                 .fillMaxSize()
-                .padding(padding)
+                .padding(paddingValues)
                 .padding(64.dp),
             verticalArrangement = Arrangement.Center,
         ) {
@@ -71,5 +62,13 @@ fun AppInactiveScreen() {
                 modifier = Modifier.fillMaxWidth(),
             )
         }
+    }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+private fun InactiveAppHomeContentPreview() {
+    SharedElementContextPreview {
+        InactiveAppHomeContent()
     }
 }

--- a/feature/home/src/main/java/com/android/developers/androidify/home/content/MainHomeContent.kt
+++ b/feature/home/src/main/java/com/android/developers/androidify/home/content/MainHomeContent.kt
@@ -1,0 +1,163 @@
+package com.android.developers.androidify.home.content
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.TextAutoSize
+import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.android.developers.androidify.theme.R
+
+@Composable
+internal fun MainHomeContent(
+    dancingBotLink: String?,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        DecorativeSquiggleLimeGreen()
+        DancingBotHeadlineText(dancingBotLink = dancingBotLink, modifier = Modifier.weight(1f))
+        DecorativeSquiggleLightGreen()
+    }
+}
+
+@Composable
+private fun ColumnScope.DecorativeSquiggleLimeGreen() {
+    val infiniteAnimation = rememberInfiniteTransition()
+    val rotationAnimation = infiniteAnimation.animateFloat(
+        0f,
+        -720f,
+        animationSpec = infiniteRepeatable(
+            tween(24000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+    )
+
+    Image(
+        painter = rememberVectorPainter(
+            ImageVector.vectorResource(R.drawable.decorative_squiggle),
+        ),
+        contentDescription = null, // decorative element
+        modifier = Modifier
+            .padding(end = 80.dp)
+            .size(60.dp)
+            .align(Alignment.End)
+            .graphicsLayer {
+                rotationZ = rotationAnimation.value
+            },
+
+        )
+}
+
+@Composable
+private fun DancingBotHeadlineText(
+    modifier: Modifier = Modifier,
+    dancingBotLink: String?,
+) {
+    Box(modifier = modifier) {
+        val animatedBot = "animatedBot"
+        val text = buildAnnotatedString {
+            append(stringResource(com.android.developers.androidify.home.R.string.customize_your_own))
+            // Attach "animatedBot" annotation on the placeholder
+            appendInlineContent(animatedBot)
+            append(stringResource(com.android.developers.androidify.home.R.string.into_an_android_bot))
+        }
+        var placeHolderSize by remember { mutableStateOf(220.sp) }
+        val inlineContent = mapOf(
+            Pair(
+                first = animatedBot,
+                second = InlineTextContent(
+                    Placeholder(
+                        width = placeHolderSize,
+                        height = placeHolderSize,
+                        placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter,
+                    ),
+                ) {
+                    AsyncImage(
+                        model = dancingBotLink,
+                        modifier = Modifier
+                            .padding(top = 32.dp)
+                            .fillMaxSize(),
+                        contentDescription = null,
+                    )
+                },
+            ),
+        )
+
+        BasicText(
+            text = text,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .padding(
+                    bottom = 16.dp,
+                    start = 16.dp,
+                    end = 16.dp,
+                ),
+            style = MaterialTheme.typography.titleLarge,
+            autoSize = TextAutoSize.StepBased(maxFontSize = 220.sp),
+            maxLines = 5,
+            onTextLayout = { result ->
+                placeHolderSize = result.layoutInput.style.fontSize * 3.5f
+            },
+            inlineContent = inlineContent,
+        )
+    }
+}
+
+@Composable
+private fun ColumnScope.DecorativeSquiggleLightGreen() {
+    val infiniteAnimation = rememberInfiniteTransition()
+    val rotationAnimation = infiniteAnimation.animateFloat(
+        0f,
+        720f,
+        animationSpec = infiniteRepeatable(
+            tween(12000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+    )
+
+    Image(
+        painter = rememberVectorPainter(
+            ImageVector.vectorResource(R.drawable.decorative_squiggle_2),
+        ),
+        contentDescription = null, // decorative element
+        modifier = Modifier
+            .padding(start = 60.dp)
+            .size(60.dp)
+            .align(Alignment.Start)
+            .graphicsLayer {
+                rotationZ = rotationAnimation.value
+            },
+    )
+}

--- a/feature/home/src/main/java/com/android/developers/androidify/home/model/HomeState.kt
+++ b/feature/home/src/main/java/com/android/developers/androidify/home/model/HomeState.kt
@@ -1,0 +1,7 @@
+package com.android.developers.androidify.home.model
+
+data class HomeState(
+    val isAppActive: Boolean = true,
+    val videoLink: String? = null,
+    val dancingDroidLink: String? = null,
+)

--- a/feature/home/src/main/java/com/android/developers/androidify/home/util/OnVisibilityChanged.kt
+++ b/feature/home/src/main/java/com/android/developers/androidify/home/util/OnVisibilityChanged.kt
@@ -1,0 +1,63 @@
+package com.android.developers.androidify.home.util
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onLayoutRectChanged
+
+/**
+ * A modifier that monitors the visibility state of a composable within specified container bounds.
+ *
+ * This modifier observes layout changes and determines whether the composable is fully visible
+ * within the given container dimensions. The visibility check is performed by ensuring all edges
+ * of the composable are within the container boundaries.
+ *
+ * @param containerWidth The width of the container in pixels. The composable must be fully
+ *                       within this horizontal boundary to be considered visible.
+ * @param containerHeight The height of the container in pixels. The composable must be fully
+ *                        within this vertical boundary to be considered visible.
+ * @param onChanged A callback function that is invoked whenever the visibility state changes.
+ *                  Receives `true` when the composable becomes fully visible within the container
+ *                  bounds, and `false` when it moves outside these bounds.
+ *
+ * @return A [Modifier] that can be chained with other modifiers.
+ *
+ * **Visibility Criteria:**
+ * A composable is considered visible when:
+ * - Its top edge is greater than 0
+ * - Its bottom edge is less than the container height
+ * - Its left edge is greater than 0
+ * - Its right edge is less than the container width
+ *
+ * **Performance Notes:**
+ * - Layout changes are throttled to 100ms to optimize performance
+ * - No debouncing is applied (debounceMillis = 0)
+ *
+ * **Example Usage:**
+ * ```kotlin
+ * Box(
+ *     modifier = Modifier
+ *         .onVisibilityChanged(
+ *             containerWidth = screenWidth,
+ *             containerHeight = screenHeight
+ *         ) { isVisible ->
+ *             if (isVisible) {
+ *                 // Handle when item becomes visible
+ *             }
+ *         }
+ * )
+ * ```
+ */
+internal fun Modifier.onVisibilityChanged(
+    containerWidth: Int,
+    containerHeight: Int,
+    onChanged: (visible: Boolean) -> Unit,
+) = this then Modifier.onLayoutRectChanged(
+    throttleMillis = 100,
+    debounceMillis = 0,
+) { relativeLayoutBounds ->
+    onChanged(
+        relativeLayoutBounds.boundsInRoot.top > 0 &&
+                relativeLayoutBounds.boundsInRoot.bottom < containerHeight &&
+                relativeLayoutBounds.boundsInRoot.left > 0 &&
+                relativeLayoutBounds.boundsInRoot.right < containerWidth,
+    )
+}


### PR DESCRIPTION
This commit introduces several changes to enhance the structure and organization of the Home screen:

- **Component Refactoring:**
    - `AppInactiveScreen` is renamed to `InactiveAppHomeContent` and moved to the `content` package.
    - `AboutScreen` has been moved to a new `about` package.
    - New components are created for better modularity:
        - `CompactPager`: Manages the compact view of the Home screen with a pager for switching between main content and video player.
        - `HomePageButton`: A dedicated composable for the "Let's Go!" button.
        - `VideoPlayerRotatedCard`: Displays the video player within a rotated card.
- **State Management:**
    - `HomeState` data class is introduced to manage the state of the Home screen, including app active status, video link, and dancing droid link.
    - `HomeViewModel` is updated to use the new `HomeState` and initialize its values from `ConfigProvider`.
- **Utilities:**
    - `onVisibilityChanged` modifier is added to detect when a composable becomes visible within its container.
- **Navigation:**
    - `MainNavigation` is updated to reflect the new location of `AboutScreen`.
- **Code Organization:**
    - Existing Home screen composables are moved into more specific files within the `feature/home` module (e.g., `component`, `content`, `model`, `util`).
    - Imports for `ViewModelStoreNavEntryDecorator`, `SavedStateNavEntryDecorator`, and `SceneSetupNavEntryDecorator` are removed from `MainNavigation.kt` as they are no longer directly used.
    - `TransformOrigin` import removed from `MainNavigation.kt`.

These changes aim to improve code readability, maintainability, and scalability of the Home screen feature.