### PR TITLE
Unregister TrustedPresentationListener to avoid memory leaks

### DIFF
--- a/app/src/main/java/com/android/developers/androidify/MainActivity.kt
+++ b/app/src/main/java/com/android/developers/androidify/MainActivity.kt
@@ -33,12 +33,16 @@ import com.android.developers.androidify.navigation.MainNavigation
 import com.android.developers.androidify.theme.AndroidifyTheme
 import com.android.developers.androidify.util.LocalOcclusion
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.function.Consumer
 
 @ExperimentalMaterial3ExpressiveApi
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     private val isWindowOccluded = mutableStateOf(false)
+    private val presentationListener = Consumer<Boolean> { isMinFractionRendered ->
+        isWindowOccluded.value = !isMinFractionRendered
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -76,8 +80,17 @@ class MainActivity : ComponentActivity() {
             windowManager.registerTrustedPresentationListener(
                 window.decorView.windowToken,
                 presentationThreshold,
-                mainExecutor
-            ) { isMinFractionRendered -> isWindowOccluded.value = !isMinFractionRendered }
+                mainExecutor,
+                presentationListener
+            )
+        }
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            val windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
+            windowManager.unregisterTrustedPresentationListener(presentationListener)
         }
     }
 


### PR DESCRIPTION
Unregister the TrustedPresentationListener in MainActivity.kt to avoid memory leaks