### PR TITLE
Replace UiAutomator onView with onElement

### DIFF
--- a/benchmark/src/main/kotlin/com/android/developers/androidify/baselineprofile/BaselineProfileGenerator.kt
+++ b/benchmark/src/main/kotlin/com/android/developers/androidify/baselineprofile/BaselineProfileGenerator.kt
@@ -45,9 +45,9 @@ class BaselineProfileGenerator {
         ) {
             uiAutomator {
                 startApp(packageName = packageName)
-                onView { textAsString() == "Let's Go" }.click()
-                onView { textAsString() == "Prompt" }.click()
-                onView { isEditable }.apply {
+                onElement { textAsString() == "Let's Go" }.click()
+                onElement{ textAsString() == "Prompt" }.click()
+                onElement{ isEditable }.apply {
                     click()
                     text =
                         "wearing brown sneakers, a red t-shirt, " +

--- a/benchmark/src/main/kotlin/com/android/developers/androidify/benchmark/PromptBenchmark.kt
+++ b/benchmark/src/main/kotlin/com/android/developers/androidify/benchmark/PromptBenchmark.kt
@@ -68,9 +68,9 @@ class PromptBenchmark {
         ) {
             uiAutomator {
                 startApp(packageName = packageName)
-                onView { textAsString() == "Let's Go" }.click()
-                onView { textAsString() == "Prompt" }.click()
-                onView { isEditable }.apply {
+                onElement { textAsString() == "Let's Go" }.click()
+                onElement { textAsString() == "Prompt" }.click()
+                onElement { isEditable }.apply {
                     click()
                     text =
                         "wearing brown sneakers, a red t-shirt, " +


### PR DESCRIPTION
The PromptBenchmark and BaselineProfileGenerator were updated to use `onElement` instead of the deprecated `onView` for UI interaction in tests.