### PR TITLE
Produce unsigned release builds on CI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,9 +65,20 @@ android {
             configure<CrashlyticsExtension> {
                 mappingFileUploadEnabled = true
             }
-            // To publish on the Play store a private signing key is required, but to allow anyone
-            // who clones the code to sign and run the release variant, use the debug signing key.
-            signingConfig = signingConfigs.named("debug").get()
+            // Conditionally apply signingConfig for release builds
+            // If the 'CI_BUILD' project property is set to 'true', do not assign a signingConfig.
+            // Otherwise, (e.g., for local Android Studio builds), sign with the debug key.
+            if (project.findProperty("CI_BUILD")?.toString()?.toBoolean() == true) {
+                // For CI builds, we want an unsigned artifact.
+                // No signingConfig is assigned here.
+                // The bundleRelease task will produce an unsigned AAB.
+                println("CI_BUILD property detected. Release build will be unsigned by Gradle.")
+            } else {
+                // For local builds (not CI), sign with the debug key to allow easy deployment.
+                // This ensures you can select the "release" variant in Android Studio and run it.
+                println("Not a CI_BUILD or CI_BUILD property not set. Signing release build with debug key.")
+                signingConfig = signingConfigs.getByName("debug")
+            }
         }
     }
     compileOptions {

--- a/build.sh
+++ b/build.sh
@@ -95,7 +95,7 @@ echo "INFO: Cleaning the project..."
 
 # Build the production release bundle without generating a baseline profile.
 echo "INFO: Building the production release bundle..."
-./gradlew app:bundleRelease -x test -Pandroid.sdk.path=$ANDROID_HOME
+./gradlew app:bundleRelease -x test -Pandroid.sdk.path=$ANDROID_HOME -PCI_BUILD=true
 
 # --- Artifact Collection ---
 echo "INFO: Preparing artifacts for Kokoro..."

--- a/build_presubmit.sh
+++ b/build_presubmit.sh
@@ -96,7 +96,7 @@ echo "INFO: Cleaning the project..."
 
 # Build the production release bundle without generating a baseline profile.
 echo "INFO: Building the production release bundle..."
-./gradlew app:bundleRelease -x test -x uploadCrashlyticsMappingFileRelease -Pandroid.sdk.path=$ANDROID_HOME
+./gradlew app:bundleRelease -x test -x uploadCrashlyticsMappingFileRelease -Pandroid.sdk.path=$ANDROID_HOME -PCI_BUILD=true
 
 # --- Artifact Collection ---
 echo "INFO: Preparing artifacts for Kokoro..."


### PR DESCRIPTION
This change modifies the build process to produce unsigned AABs for release builds when executed in a CI environment.

The `CI_BUILD=true` project property is introduced and passed during CI builds (`build.sh` and `build_presubmit.sh`).

In `app/build.gradle.kts`, the release build type now conditionally applies the `signingConfig`. If `CI_BUILD` is true, no `signingConfig` is applied, resulting in an unsigned AAB. Otherwise (for local builds), the debug signing key is used as before.

This allows CI to build release artifacts without requiring access to production signing keys, while developers can still build and run the release variant locally using the debug key.