### PR TITLE
Update build scripts to improve intoto.jsonl file handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,7 @@ plugins {
     alias(libs.plugins.crashlytics)
     alias(libs.plugins.baselineprofile)
     id("com.google.android.gms.oss-licenses-plugin")
+    id("org.spdx.sbom") version "0.9.0"
 }
 
 android {
@@ -99,6 +100,16 @@ baselineProfile() {
     dexLayoutOptimization = true
 }
 
+spdxSbom {
+    targets {
+        // create a target named "release",
+        // this is used for the task name (spdxSbomForRelease)
+        // and output file (release.spdx.json)
+        create("release") {
+            configurations.set(listOf("releaseRuntimeClasspath"))
+        }
+    }
+}
 dependencies {
     debugImplementation(libs.leakcanary.android)
     implementation(libs.androidx.app.startup)
@@ -155,3 +166,4 @@ androidComponents {
         variantBuilder.enableAndroidTest = false
     }
 }
+

--- a/build.sh
+++ b/build.sh
@@ -95,7 +95,7 @@ echo "INFO: Cleaning the project..."
 
 # Build the production release bundle without generating a baseline profile.
 echo "INFO: Building the production release bundle..."
-./gradlew app:bundleRelease -x test -Pandroid.sdk.path=$ANDROID_HOME -PCI_BUILD=true
+./gradlew app:bundleRelease app:spdxSbomForRelease -x test -Pandroid.sdk.path=$ANDROID_HOME -PCI_BUILD=true
 
 # --- Artifact Collection ---
 echo "INFO: Preparing artifacts for Kokoro..."
@@ -131,6 +131,10 @@ if [[ -f "$AAB_PATH" ]]; then
      echo "FAILURE: No .intoto.jsonl files found."
      exit 1
    fi
+
+  echo "INFO: Copying SPDX SBOM..."
+  # The output file from app:spdxSbomForRelease is build/spdx/release.spdx.json
+  cp app/build/spdx/release.spdx.json "${KOKORO_ARTIFACTS_DIR}/artifacts/app-release.spdx.json"
 
  else
    echo "FAILURE: AAB not found at ${AAB_PATH}"

--- a/build.sh
+++ b/build.sh
@@ -127,10 +127,9 @@ if [[ -f "$AAB_PATH" ]]; then
      echo "INFO: Copying .intoto.jsonl files to ${ARTIFACT_DEST_DIR}/"
      # Use print0 and xargs -0 for safe handling of filenames with spaces or special characters
      find . -type f -name "*.intoto.jsonl" -print0 | xargs -0 -I {} cp {} "${ARTIFACT_DEST_DIR}/"
-   else
-     echo "FAILURE: No .intoto.jsonl files found."
-     exit 1
-   fi
+  else
+    echo "INFO: No .intoto.jsonl files found."
+  fi
 
   echo "INFO: Copying SPDX SBOM..."
   # The output file from app:spdxSbomForRelease is build/spdx/release.spdx.json

--- a/build.sh
+++ b/build.sh
@@ -116,17 +116,23 @@ if [[ -f "$AAB_PATH" ]]; then
   cp "${AAB_PATH}" "${ARTIFACT_DEST_DIR}/app-release-unsigned.aab"
   echo "SUCCESS: AAB copied to ${ARTIFACT_DEST_DIR}"
 
-  # Copy any .intointo.jsonl files to the artifact directory
-  echo "INFO: Searching for and copying .intointo.jsonl files..."
-  ls
-  echo "INFO: Logging output directory contents"
-  ls "$AAB_SRC_DIR/"
-  find . -type f -name "*.intointo.jsonl" -print0 | xargs -0 -I {} cp {} "${ARTIFACT_DEST_DIR}/"
-  echo "INFO: Finished copying .intointo.jsonl files."
+   # Find and list the files before copying
+   # Store the find results in a variable to avoid running find twice
+   # and to handle the case where no files are found gracefully.
+   intoto_files=$(find . -type f -name "*.intoto.jsonl")
 
-else
-  echo "FAILURE: AAB not found at ${AAB_PATH}"
-  # Optionally fail the build: exit 1
-fi
+   if [ -n "$intoto_files" ]; then
+     echo "INFO: Found the following .intoto.jsonl files:"
+     echo "$intoto_files" # This will list each file on a new line
+     echo "INFO: Copying .intoto.jsonl files to ${ARTIFACT_DEST_DIR}/"
+     # Use print0 and xargs -0 for safe handling of filenames with spaces or special characters
+     find . -type f -name "*.intoto.jsonl" -print0 | xargs -0 -I {} cp {} "${ARTIFACT_DEST_DIR}/"
+   else
+     echo "FAILURE: No .intoto.jsonl files found."
+     exit 1
+   fi
 
-exit 0
+ else
+   echo "FAILURE: AAB not found at ${AAB_PATH}"
+   exit 1
+ fi

--- a/build_presubmit.sh
+++ b/build_presubmit.sh
@@ -96,7 +96,7 @@ echo "INFO: Cleaning the project..."
 
 # Build the production release bundle without generating a baseline profile.
 echo "INFO: Building the production release bundle..."
-./gradlew app:bundleRelease -x test -x uploadCrashlyticsMappingFileRelease -Pandroid.sdk.path=$ANDROID_HOME -PCI_BUILD=true
+./gradlew app:bundleRelease app:spdxSbomForRelease -x test -x uploadCrashlyticsMappingFileRelease -Pandroid.sdk.path=$ANDROID_HOME -PCI_BUILD=true
 
 # --- Artifact Collection ---
 echo "INFO: Preparing artifacts for Kokoro..."
@@ -132,6 +132,10 @@ if [[ -f "$AAB_PATH" ]]; then
     echo "FAILURE: No .intoto.jsonl files found."
     exit 1
   fi
+
+  echo "INFO: Copying SPDX SBOM..."
+  # The output file from app:spdxSbomForRelease is build/spdx/release.spdx.json
+  cp app/build/spdx/release.spdx.json "${KOKORO_ARTIFACTS_DIR}/artifacts/app-release.spdx.json"
 
 else
   echo "FAILURE: AAB not found at ${AAB_PATH}"

--- a/build_presubmit.sh
+++ b/build_presubmit.sh
@@ -117,17 +117,25 @@ if [[ -f "$AAB_PATH" ]]; then
   cp "${AAB_PATH}" "${ARTIFACT_DEST_DIR}/app-release-unsigned.aab"
   echo "SUCCESS: AAB copied to ${ARTIFACT_DEST_DIR}"
 
-  # Copy any .intointo.jsonl files to the artifact directory
-  echo "INFO: Searching for and copying .intointo.jsonl files..."
-  ls
-  echo "INFO: Logging output directory contents"
-  ls "$AAB_SRC_DIR/"
-  find . -type f -name "*.intointo.jsonl" -print0 | xargs -0 -I {} cp {} "${ARTIFACT_DEST_DIR}/"
-  echo "INFO: Finished copying .intointo.jsonl files."
+  # Find and list the files before copying
+  # Store the find results in a variable to avoid running find twice
+  # and to handle the case where no files are found gracefully.
+  intoto_files=$(find . -type f -name "*.intoto.jsonl")
+
+  if [ -n "$intoto_files" ]; then
+    echo "INFO: Found the following .intoto.jsonl files:"
+    echo "$intoto_files" # This will list each file on a new line
+    echo "INFO: Copying .intoto.jsonl files to ${ARTIFACT_DEST_DIR}/"
+    # Use print0 and xargs -0 for safe handling of filenames with spaces or special characters
+    find . -type f -name "*.intoto.jsonl" -print0 | xargs -0 -I {} cp {} "${ARTIFACT_DEST_DIR}/"
+  else
+    echo "FAILURE: No .intoto.jsonl files found."
+    exit 1
+  fi
 
 else
   echo "FAILURE: AAB not found at ${AAB_PATH}"
-  # Optionally fail the build: exit 1
+  exit 1
 fi
 
 exit 0

--- a/build_presubmit.sh
+++ b/build_presubmit.sh
@@ -129,8 +129,7 @@ if [[ -f "$AAB_PATH" ]]; then
     # Use print0 and xargs -0 for safe handling of filenames with spaces or special characters
     find . -type f -name "*.intoto.jsonl" -print0 | xargs -0 -I {} cp {} "${ARTIFACT_DEST_DIR}/"
   else
-    echo "FAILURE: No .intoto.jsonl files found."
-    exit 1
+    echo "INFO: No .intoto.jsonl files found."
   fi
 
   echo "INFO: Copying SPDX SBOM..."

--- a/kokoro/gcp_ubuntu_docker/continuous.cfg
+++ b/kokoro/gcp_ubuntu_docker/continuous.cfg
@@ -4,6 +4,7 @@ action {
   define_artifacts {
     regex: "artifacts/**.aab"
     regex: "artifacts/**.intoto.jsonl"
+    sbom_regex: "artifacts/app-release.spdx.json"
     # Optional: Removes the "artifacts/" part from the path in the artifact storage
     strip_prefix: "artifacts"
     fail_if_no_artifacts: true

--- a/kokoro/gcp_ubuntu_docker/presubmit.cfg
+++ b/kokoro/gcp_ubuntu_docker/presubmit.cfg
@@ -4,7 +4,7 @@ action {
   define_artifacts {
     regex: "artifacts/**.aab"
     regex: "artifacts/**.intoto.jsonl"
-
+    sbom_regex: "artifacts/app-release.spdx.json"
     # Optional: Removes the "artifacts/" part from the path in the artifact storage
     strip_prefix: "artifacts"
     fail_if_no_artifacts: true

--- a/kokoro/gcp_ubuntu_docker/release.cfg
+++ b/kokoro/gcp_ubuntu_docker/release.cfg
@@ -4,6 +4,7 @@ action {
   define_artifacts {
     regex: "artifacts/**.aab"
     regex: "artifacts/**.intoto.jsonl"
+    sbom_regex: "artifacts/app-release.spdx.json"
 
     # Optional: Removes the "artifacts/" part from the path in the artifact storage
     strip_prefix: "artifacts"


### PR DESCRIPTION
This commit modifies `build_presubmit.sh` and `build.sh` to:
- List found `.intoto.jsonl` files before copying.
- Exit with a failure status if no `.intoto.jsonl` files are found.
- Exit with a failure status if the AAB file is not found.