### PR TITLE
Offscreen bitmap renderer: 

### DIFF
--- a/feature/results/src/main/java/com/android/developers/androidify/customize/CustomizeExportViewModel.kt
+++ b/feature/results/src/main/java/com/android/developers/androidify/customize/CustomizeExportViewModel.kt
@@ -54,7 +54,6 @@ class CustomizeExportViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        composableBitmapRenderer.dispose()
     }
     fun setArguments(
         resultImageUrl: Bitmap,


### PR DESCRIPTION
Revert to not re-using the surface due to crashes with `android.view.WindowManager$BadTokenException: Unable to add window android.view.ViewRootImpl$W@8189b37 -- permission denied for window type 2030`

`