### PR TITLE
Update ComposableBitmapRendererImpl.kt to use the context from Presentation Layer

### DIFF
--- a/feature/results/src/main/java/com/android/developers/androidify/customize/ComposableBitmapRendererImpl.kt
+++ b/feature/results/src/main/java/com/android/developers/androidify/customize/ComposableBitmapRendererImpl.kt
@@ -58,7 +58,10 @@ import javax.inject.Singleton
 
 interface ComposableBitmapRenderer {
 
-    suspend fun renderComposableToBitmap(canvasSize: Size, composableContent: @Composable () -> Unit): Bitmap?
+    suspend fun renderComposableToBitmap(
+        canvasSize: Size,
+        composableContent: @Composable () -> Unit,
+    ): Bitmap?
 }
 
 /**
@@ -74,20 +77,22 @@ interface ComposableBitmapRenderer {
  *              }
  */
 @Singleton
-class ComposableBitmapRendererImpl @Inject constructor(private val application: Application) : ComposableBitmapRenderer {
+class ComposableBitmapRendererImpl @Inject constructor(private val application: Application) :
+    ComposableBitmapRenderer {
 
     private suspend fun <T> useVirtualDisplay(callback: suspend (display: Display) -> T): T? {
         val texture = SurfaceTexture(false)
         val surface = Surface(texture)
-        val virtualDisplay: VirtualDisplay? =
-                (application.getSystemService(DISPLAY_SERVICE) as DisplayManager).createVirtualDisplay(
-                    "virtualDisplay",
-                    1,
-                    1,
-                    72,
-                    surface,
-                    DisplayManager.VIRTUAL_DISPLAY_FLAG_OWN_CONTENT_ONLY,
-                )
+        val outerContext = application.resources.displayMetrics
+        val virtualDisplay =
+            application.getSystemService(DisplayManager::class.java).createVirtualDisplay(
+                "virtualDisplay",
+                outerContext.widthPixels,
+                outerContext.heightPixels,
+                outerContext.densityDpi,
+                surface,
+                DisplayManager.VIRTUAL_DISPLAY_FLAG_OWN_CONTENT_ONLY,
+            )
 
         val result = callback(virtualDisplay!!.display)
         virtualDisplay.release()
@@ -96,7 +101,10 @@ class ComposableBitmapRendererImpl @Inject constructor(private val application: 
         return result
     }
 
-    override suspend fun renderComposableToBitmap(canvasSize: Size, composableContent: @Composable () -> Unit): Bitmap? {
+    override suspend fun renderComposableToBitmap(
+        canvasSize: Size,
+        composableContent: @Composable () -> Unit,
+    ): Bitmap? {
         val bitmap = useVirtualDisplay { display ->
             val outputDensity = Density(1f)
 
@@ -119,6 +127,7 @@ class ComposableBitmapRendererImpl @Inject constructor(private val application: 
         }
         return bitmap
     }
+
     private data class CaptureComposableScope(val capture: () -> Unit)
 
     private fun Size.roundedToIntSize(): IntSize =
@@ -172,7 +181,7 @@ class ComposableBitmapRendererImpl @Inject constructor(private val application: 
             }
         }
 
-        val composeView = ComposeView(context).apply {
+        val composeView = ComposeView(presentation.context).apply {
             val intSize = with(density) { size.toSize().roundedToIntSize() }
             require(intSize.width > 0 && intSize.height > 0) { "pixel size must not have zero dimension" }
 


### PR DESCRIPTION
 Switch to the height and width of the context for the virtual display, due to StrictMode reporting issues with incorrect context usage.

```
com.google.android.libraries.strictmode.StrictModePolicyViolation: INCORRECT_CONTEXT_USE
  at android.os.StrictMode.onIncorrectContextUsed(StrictMode.java:2491)
  at android.os.StrictMode.assertConfigurationContext(StrictMode.java:2527)
  at android.view.ViewConfiguration.get(ViewConfiguration.java:641)
  at android.view.View.<init>(View.java:6013)
  at android.view.View.<init>(View.java:6146)
  at android.view.ViewGroup.<init>(ViewGroup.java:716)
  at android.view.ViewGroup.<init>(ViewGroup.java:712)
  at androidx.compose.ui.platform.AbstractComposeView.<init>(ComposeView.android.kt:60
```

cc @yschimke 