### PR TITLE
Adds check for Wearable API

### DIFF
--- a/watchface/src/main/java/com/android/developers/androidify/watchface/creator/Signer.kt
+++ b/watchface/src/main/java/com/android/developers/androidify/watchface/creator/Signer.kt
@@ -39,7 +39,7 @@ import java.security.cert.X509Certificate
 import java.util.Calendar
 import java.util.Date
 
-private val keyAlias : String
+private val keyAlias: String
     get() = "com.android.developers.androidify.ApkSigningKey-" + BuildConfig.BUILD_TYPE
 private val certAlias: String
     get() = "com.android.developers.androidify.Cert-" + BuildConfig.BUILD_TYPE

--- a/watchface/src/main/java/com/android/developers/androidify/watchface/transfer/WearAssetTransmitter.kt
+++ b/watchface/src/main/java/com/android/developers/androidify/watchface/transfer/WearAssetTransmitter.kt
@@ -83,7 +83,7 @@ class WearAssetTransmitterImpl @Inject constructor(
     override val watchFaceInstallationUpdates = callbackFlow {
         trySend(WatchFaceInstallationStatus.NotStarted)
 
-        var listener : MessageClient.OnMessageReceivedListener? = null
+        var listener: MessageClient.OnMessageReceivedListener? = null
 
         /**
          * Some devices don't have access to Wearable API via Play Services, so it is necessary to
@@ -100,7 +100,7 @@ class WearAssetTransmitterImpl @Inject constructor(
                     }
                 }
             }
-            messageClient.addListener(listener).await() 
+            messageClient.addListener(listener).await()
         }
         awaitClose {
             listener?.let {

--- a/watchface/src/main/java/com/android/developers/androidify/watchface/transfer/WearDeviceRepository.kt
+++ b/watchface/src/main/java/com/android/developers/androidify/watchface/transfer/WearDeviceRepository.kt
@@ -57,7 +57,7 @@ class WearDeviceRepositoryImpl @Inject constructor(
             val reachableCapability =
                 capabilityClient.getCapability(
                     ANDROIDIFY_INSTALLED,
-                    CapabilityClient.FILTER_REACHABLE
+                    CapabilityClient.FILTER_REACHABLE,
                 )
                     .await()
 

--- a/watchface/src/main/java/com/android/developers/androidify/watchface/transfer/WearDeviceRepository.kt
+++ b/watchface/src/main/java/com/android/developers/androidify/watchface/transfer/WearDeviceRepository.kt
@@ -45,23 +45,39 @@ class WearDeviceRepositoryImpl @Inject constructor(
     private val capabilityClient: CapabilityClient by lazy { Wearable.getCapabilityClient(context) }
 
     override val connectedWatch = callbackFlow {
-        val allDevices = nodeClient.connectedNodes.await().toSet()
-        val reachableCapability =
-            capabilityClient.getCapability(ANDROIDIFY_INSTALLED, CapabilityClient.FILTER_REACHABLE)
-                .await()
+        var capabilityListener: CapabilityClient.OnCapabilityChangedListener? = null
 
-        val installedDevices = reachableCapability.nodes.toSet()
+        /**
+         * Some devices don't have access to Wearable API via Play Services, so it is necessary to
+         * check for this scenario first before trying to use the API.
+         */
+        val apiAvailable = WearableApiAvailability.isAvailable(nodeClient)
+        if (apiAvailable) {
+            val allDevices = nodeClient.connectedNodes.await().toSet()
+            val reachableCapability =
+                capabilityClient.getCapability(
+                    ANDROIDIFY_INSTALLED,
+                    CapabilityClient.FILTER_REACHABLE
+                )
+                    .await()
 
-        trySend(selectConnectedDevice(installedDevices, allDevices))
+            val installedDevices = reachableCapability.nodes.toSet()
+            trySend(selectConnectedDevice(installedDevices, allDevices))
 
-        val capabilityListener = CapabilityClient.OnCapabilityChangedListener { capabilityInfo ->
-            val installedDevicesUpdated = capabilityInfo.nodes.toSet()
+            capabilityListener =
+                CapabilityClient.OnCapabilityChangedListener { capabilityInfo ->
+                    val installedDevicesUpdated = capabilityInfo.nodes.toSet()
 
-            trySend(selectConnectedDevice(installedDevicesUpdated, allDevices))
+                    trySend(selectConnectedDevice(installedDevicesUpdated, allDevices))
+                }
+            capabilityClient.addListener(capabilityListener, ANDROIDIFY_INSTALLED)
+        } else {
+            trySend(null)
         }
-        capabilityClient.addListener(capabilityListener, ANDROIDIFY_INSTALLED)
         awaitClose {
-            capabilityClient.removeListener(capabilityListener)
+            capabilityListener?.let {
+                capabilityClient.removeListener(it)
+            }
         }
     }
 
@@ -89,4 +105,6 @@ class WearDeviceRepositoryImpl @Inject constructor(
             null
         }
     }
+
+    private val TAG = "WearDeviceRepository"
 }

--- a/watchface/src/main/java/com/android/developers/androidify/watchface/transfer/WearDeviceRepository.kt
+++ b/watchface/src/main/java/com/android/developers/androidify/watchface/transfer/WearDeviceRepository.kt
@@ -105,6 +105,4 @@ class WearDeviceRepositoryImpl @Inject constructor(
             null
         }
     }
-
-    private val TAG = "WearDeviceRepository"
 }

--- a/watchface/src/main/java/com/android/developers/androidify/watchface/transfer/WearableApiAvailability.kt
+++ b/watchface/src/main/java/com/android/developers/androidify/watchface/transfer/WearableApiAvailability.kt
@@ -1,0 +1,30 @@
+package com.android.developers.androidify.watchface.transfer
+
+import android.util.Log
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.common.api.AvailabilityException
+import com.google.android.gms.common.api.GoogleApi
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Checks whether a given Wearable Data Layer API is available on this device.
+ */
+object WearableApiAvailability {
+    suspend fun isAvailable(api: GoogleApi<*>): Boolean {
+        return try {
+            GoogleApiAvailability.getInstance()
+                .checkApiAvailability(api)
+                .await()
+
+            true
+        } catch (e: AvailabilityException) {
+            Log.d(
+                TAG,
+                "${api.javaClass.simpleName} API is not available in this device.",
+            )
+            false
+        }
+    }
+
+    val TAG = "WearableApiAvailability"
+}

--- a/watchface/src/main/java/com/android/developers/androidify/watchface/transfer/WearableApiAvailability.kt
+++ b/watchface/src/main/java/com/android/developers/androidify/watchface/transfer/WearableApiAvailability.kt
@@ -25,21 +25,19 @@ import kotlinx.coroutines.tasks.await
  * Checks whether a given Wearable Data Layer API is available on this device.
  */
 object WearableApiAvailability {
-    suspend fun isAvailable(api: GoogleApi<*>): Boolean {
-        return try {
-            GoogleApiAvailability.getInstance()
-                .checkApiAvailability(api)
-                .await()
+    suspend fun isAvailable(api: GoogleApi<*>) = try {
+        GoogleApiAvailability.getInstance()
+            .checkApiAvailability(api)
+            .await()
 
-            true
-        } catch (e: AvailabilityException) {
-            Log.d(
-                TAG,
-                "${api.javaClass.simpleName} API is not available in this device.",
-            )
-            false
-        }
+        true
+    } catch (e: AvailabilityException) {
+        Log.d(
+            TAG,
+            "${api.javaClass.simpleName} API is not available in this device.",
+        )
+        false
     }
-
-    val TAG = "WearableApiAvailability"
 }
+
+private const val TAG = "WearableApiAvailability"

--- a/watchface/src/main/java/com/android/developers/androidify/watchface/transfer/WearableApiAvailability.kt
+++ b/watchface/src/main/java/com/android/developers/androidify/watchface/transfer/WearableApiAvailability.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.android.developers.androidify.watchface.transfer
 
 import android.util.Log


### PR DESCRIPTION
Some devices (phones without Play Services, possibly tablets?) don't have access to the Wearable APIs. Attempting to invoke them on these devices results in a fatal error:

```
E  FATAL EXCEPTION: main
     Process: com.android.developers.androidify, PID: 26148
     com.google.android.gms.common.api.ApiException: 17: API: Wearable.API is not available on this device. Connection failed with: ConnectionResult{statusCode=API_UNAVAILABLE, resolution=null, message=null}
```

This pull request adds a check for the Wearable API availability both in `WearDeviceRepository` and in `WearAssetTransmitter`.

Where the API is not available, `WearDeviceRepository` reports that no device is connected and `WearAssetTransmitter` reports that no transmission is ongoing.

