### PR TITLE
feat(camera): volume buttons act as shutter (only on camera screen, respects enabled state)

### DIFF
--- a/app/src/main/java/com/android/developers/androidify/MainActivity.kt
+++ b/app/src/main/java/com/android/developers/androidify/MainActivity.kt
@@ -17,6 +17,7 @@ package com.android.developers.androidify
 
 import android.os.Build
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.WindowManager
 import android.window.TrustedPresentationThresholds
 import androidx.activity.ComponentActivity
@@ -28,6 +29,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import com.android.developers.androidify.camera.HardwareKeyManager
 import com.android.developers.androidify.navigation.MainNavigation
 import com.android.developers.androidify.theme.AndroidifyTheme
 import com.android.developers.androidify.util.LocalOcclusion
@@ -94,4 +96,12 @@ class MainActivity : ComponentActivity() {
             windowManager.unregisterTrustedPresentationListener(presentationListener)
         }
     }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean =
+        if (HardwareKeyManager.dispatchDown(keyCode, event)) true
+        else super.onKeyDown(keyCode, event)
+
+    override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean =
+        if (HardwareKeyManager.dispatchUp(keyCode, event)) true
+        else super.onKeyUp(keyCode, event)
 }

--- a/feature/camera/src/main/java/com/android/developers/androidify/camera/CameraScreen.kt
+++ b/feature/camera/src/main/java/com/android/developers/androidify/camera/CameraScreen.kt
@@ -226,6 +226,10 @@ fun StatelessCameraPreviewContent(
                 enabled = detectedPose,
                 captureImageClicked = requestCaptureImage,
             )
+            RegisterHardwareShutter(
+                enabled = detectedPose,
+                onCapture = requestCaptureImage,
+            )
         },
         flipCameraButton = { flipModifier ->
             if (canFlipCamera) {

--- a/feature/camera/src/main/java/com/android/developers/androidify/camera/HardwareKeyManager.kt
+++ b/feature/camera/src/main/java/com/android/developers/androidify/camera/HardwareKeyManager.kt
@@ -1,0 +1,27 @@
+package com.android.developers.androidify.camera
+
+import android.view.KeyEvent
+import java.util.concurrent.CopyOnWriteArrayList
+
+object HardwareKeyManager {
+    interface Handler {
+        /** Higher number = higher priority */
+        val priority: Int get() = 0
+        fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean = false
+        fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean = false
+    }
+
+    private val handlers = CopyOnWriteArrayList<Handler>()
+
+    fun register(handler: Handler): AutoCloseable {
+        handlers.add(handler)
+        handlers.sortByDescending { it.priority }
+        return AutoCloseable { handlers.remove(handler) }
+    }
+
+    fun dispatchDown(keyCode: Int, event: KeyEvent): Boolean =
+        handlers.any { it.onKeyDown(keyCode, event) }
+
+    fun dispatchUp(keyCode: Int, event: KeyEvent): Boolean =
+        handlers.any { it.onKeyUp(keyCode, event) }
+}


### PR DESCRIPTION
Intercepts Volume Up/Down (and KEYCODE_CAMERA) to trigger captureImage(). Scoped to the camera screen only; otherwise volume works normally. Gated by the same shutter enabled flag as the UI button; ignores long-press repeats. Activity forwards keys via lightweight HardwareKeyManager; screen registers via DisposableEffect. CameraCaptureButton remains UI-only (no hardware-key code).