### PR TITLE
Catch exception when attempting to load launch a PickVisualMediaRequest with no applicable activities

### DIFF
--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationScreen.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationScreen.kt
@@ -25,7 +25,6 @@ package com.android.developers.androidify.creation
 import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -52,12 +51,12 @@ fun CreationScreen(
     ) {
         creationViewModel.onBackPress()
     }
-    val pickMedia = rememberLauncherForActivityResult(PickVisualMedia()) { uri ->
+    val snackbarHostState by creationViewModel.snackbarHostState.collectAsStateWithLifecycle()
+    val launcher = rememberLauncherForActivityResult(PickVisualMedia()) { uri ->
         if (uri != null) {
             creationViewModel.onImageSelected(uri)
         }
     }
-    val snackbarHostState by creationViewModel.snackbarHostState.collectAsStateWithLifecycle()
 
     LaunchedEffect(uiState.resultBitmapUri) {
         uiState.resultBitmapUri?.let { resultBitmapUri ->
@@ -84,7 +83,9 @@ fun CreationScreen(
                 onBackPressed = onBackPressed,
                 onAboutPressed = onAboutPressed,
                 uiState = uiState,
-                onChooseImageClicked = { pickMedia.launch(PickVisualMediaRequest(it)) },
+                onChooseImageClicked = {
+                    creationViewModel.launchImageChooser(launcher)
+                },
                 onPromptOptionSelected = creationViewModel::onSelectedPromptOptionChanged,
                 onUndoPressed = creationViewModel::onUndoPressed,
                 onPromptGenerationPressed = creationViewModel::onPromptGenerationClicked,

--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationViewModel.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationViewModel.kt
@@ -17,6 +17,9 @@ package com.android.developers.androidify.creation
 
 import android.content.Context
 import android.net.Uri
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.ui.graphics.Color
@@ -93,6 +96,15 @@ class CreationViewModel @AssistedInject constructor(
         }
     }
 
+    fun launchImageChooser(launcher: ManagedActivityResultLauncher<PickVisualMediaRequest, Uri?>) {
+        try {
+            launcher.launch(PickVisualMediaRequest(PickVisualMedia.ImageOnly))
+        } catch (exception: Exception) {
+            Timber.e(exception, "Failed to open the visual media picker")
+            displayOpenImageChooserError()
+        }
+    }
+
     fun onBotColorChanged(botColor: BotColor) {
         _uiState.update {
             it.copy(botColor = botColor)
@@ -129,6 +141,12 @@ class CreationViewModel @AssistedInject constructor(
                     it.copy(promptGenerationInProgress = false)
                 }
             }
+        }
+    }
+
+    fun displayOpenImageChooserError() {
+        viewModelScope.launch {
+            _snackbarHostState.value.showSnackbar(context.getString(R.string.error_open_visual_media_picker))
         }
     }
 

--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/EditScreen.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/EditScreen.kt
@@ -24,7 +24,6 @@ package com.android.developers.androidify.creation
 
 import android.net.Uri
 import androidx.activity.ComponentActivity
-import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -67,7 +66,7 @@ fun EditScreen(
     onBackPressed: () -> Unit,
     onAboutPressed: () -> Unit,
     uiState: CreationState,
-    onChooseImageClicked: (PickVisualMedia.VisualMediaType) -> Unit,
+    onChooseImageClicked: () -> Unit,
     onPromptOptionSelected: (PromptType) -> Unit,
     onUndoPressed: () -> Unit,
     onPromptGenerationPressed: () -> Unit,

--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/EditScreenCompact.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/EditScreenCompact.kt
@@ -23,7 +23,6 @@
 package com.android.developers.androidify.creation
 
 import android.net.Uri
-import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -71,7 +70,7 @@ fun EditScreenContentsCompact(
     dropBehaviourFactory: DropBehaviourFactory,
     onCameraPressed: () -> Unit,
     uiState: CreationState,
-    onChooseImageClicked: (PickVisualMedia.VisualMediaType) -> Unit,
+    onChooseImageClicked: () -> Unit,
     onPromptOptionSelected: (PromptType) -> Unit,
     onUndoPressed: () -> Unit,
     onPromptGenerationPressed: () -> Unit,
@@ -97,9 +96,7 @@ fun EditScreenContentsCompact(
             dropBehaviourFactory = dropBehaviourFactory,
             modifier = Modifier.weight(1f),
             onCameraPressed = onCameraPressed,
-            onChooseImageClicked = {
-                onChooseImageClicked(PickVisualMedia.ImageOnly)
-            },
+            onChooseImageClicked = onChooseImageClicked,
             onUndoPressed = onUndoPressed,
             onPromptGenerationPressed = onPromptGenerationPressed,
             onSelectedPromptOptionChanged = onPromptOptionSelected,

--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/EditScreenMedium.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/EditScreenMedium.kt
@@ -23,7 +23,6 @@
 package com.android.developers.androidify.creation
 
 import android.net.Uri
-import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -56,7 +55,7 @@ fun EditScreenContentsMedium(
     dropBehaviourFactory: DropBehaviourFactory,
     onCameraPressed: () -> Unit,
     uiState: CreationState,
-    onChooseImageClicked: (PickVisualMedia.VisualMediaType) -> Unit,
+    onChooseImageClicked: () -> Unit,
     onPromptOptionSelected: (PromptType) -> Unit,
     onUndoPressed: () -> Unit,
     onPromptGenerationPressed: () -> Unit,
@@ -79,9 +78,7 @@ fun EditScreenContentsMedium(
                 dropBehaviourFactory = dropBehaviourFactory,
                 modifier = Modifier.weight(.6f),
                 onCameraPressed = onCameraPressed,
-                onChooseImageClicked = {
-                    onChooseImageClicked(PickVisualMedia.ImageOnly)
-                },
+                onChooseImageClicked = onChooseImageClicked,
                 onUndoPressed = onUndoPressed,
                 onPromptGenerationPressed = onPromptGenerationPressed,
                 onSelectedPromptOptionChanged = onPromptOptionSelected,

--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/xr/EditScreenSpatial.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/xr/EditScreenSpatial.kt
@@ -16,7 +16,6 @@
 package com.android.developers.androidify.creation.xr
 
 import android.net.Uri
-import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -66,7 +65,7 @@ fun EditScreenSpatial(
     onAboutPressed: () -> Unit,
     uiState: CreationState,
     snackbarHostState: SnackbarHostState,
-    onChooseImageClicked: (PickVisualMedia.VisualMediaType) -> Unit,
+    onChooseImageClicked: () -> Unit,
     onPromptOptionSelected: (PromptType) -> Unit,
     onUndoPressed: () -> Unit,
     onPromptGenerationPressed: () -> Unit,
@@ -131,9 +130,7 @@ fun EditScreenSpatial(
                                     uiState = uiState,
                                     dropBehaviourFactory = dropBehaviourFactory,
                                     onCameraPressed = onCameraPressed,
-                                    onChooseImageClicked = {
-                                        onChooseImageClicked(PickVisualMedia.ImageOnly)
-                                    },
+                                    onChooseImageClicked = onChooseImageClicked,
                                     onUndoPressed = onUndoPressed,
                                     onPromptGenerationPressed = onPromptGenerationPressed,
                                     onSelectedPromptOptionChanged = onPromptOptionSelected,

--- a/feature/creation/src/main/res/values/strings.xml
+++ b/feature/creation/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@
     <string name="error_upload_generic">An error occurred whilst uploading, try again later.</string>
     <string name="error_image_validation">The image is not a valid picture of a person.</string>
     <string name="error_choose_image_prompt">Choose an image or use a prompt instead.</string>
+    <string name="error_open_visual_media_picker">An error occurred whilst opening the media picker.</string>
     <string-array name="generation_prompts">
         <item>Oh, this one is going to be nice…</item>
         <item>Now… onto the spray paint</item>


### PR DESCRIPTION
Handles an uncaught exception when attempting to launch a media picker intent with no valid target activities installed on the device.