### PR TITLE
Clean up the logic to disable of android device tests

### DIFF
--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -52,7 +52,7 @@ android {
 
 // Explicitly disable the connectedAndroidTest task for this module
 androidComponents {
-    beforeVariants(selector().all()) { variant ->
+    beforeVariants { variant ->
         variant.enableAndroidTest = false
     }
 }
@@ -91,9 +91,4 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.core)
-
-    androidTestImplementation(libs.androidx.ui.test.junit4)
-    androidTestImplementation(libs.hilt.android.testing)
-    androidTestImplementation(projects.core.testing)
-    kspAndroidTest(libs.hilt.compiler)
 }

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -41,7 +41,7 @@ android {
 
 // Explicitly disable the connectedAndroidTest task for this module
 androidComponents {
-    beforeVariants(selector().all()) { variant ->
+    beforeVariants { variant ->
         variant.enableAndroidTest = false
     }
 }
@@ -61,11 +61,5 @@ dependencies {
     implementation(projects.feature.results)
     implementation(projects.watchface)
     implementation(projects.wear.common)
-
     ksp(libs.hilt.compiler)
-
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.ui.test.junit4)
-    androidTestImplementation(libs.hilt.android.testing)
-    kspAndroidTest(libs.hilt.compiler)
 }

--- a/core/util/build.gradle.kts
+++ b/core/util/build.gradle.kts
@@ -39,7 +39,7 @@ android {
 }
 // Explicitly disable the connectedAndroidTest task for this module
 androidComponents {
-    beforeVariants(selector().all()) { variant ->
+    beforeVariants { variant ->
         variant.enableAndroidTest = false
     }
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 }
 // Explicitly disable the connectedAndroidTest task for this module
 androidComponents {
-    beforeVariants(selector().all()) { variant ->
+    beforeVariants { variant ->
         variant.enableAndroidTest = false
     }
 }


### PR DESCRIPTION
- selector().all() is the default value, drop it
- Remove androidTestImplementation from projects that disable tests